### PR TITLE
Macos arm build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        arch: [amd64]
+        cgo: [0]
         os: [macos-latest, windows-latest, ubuntu-latest ]
+        include:
+          - os: macos-latest
+            arch: arm64
     steps:
     - uses: actions/checkout@v3
 
@@ -24,6 +29,9 @@ jobs:
         go-version: 1.17
 
     - name: Build
+      env:
+        GOARCH: ${{matrix.arch}}
+        CGO_ENABLED: ${{matrix.cgo}}
       run: go build -v ./...
 
     - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,7 @@ jobs:
         include:
           - os: macos-latest
             arch: arm64
+            cgo: 1
     steps:
     - uses: actions/checkout@v3
 
@@ -32,7 +33,7 @@ jobs:
       env:
         GOARCH: ${{matrix.arch}}
         CGO_ENABLED: ${{matrix.cgo}}
-      run: go build -v ./...
+      run: go build -o cdt -ldflags='-X main.version=dev -X main.binaryName=cdt'
 
     - name: Test
       run: go test -v ./...


### PR DESCRIPTION
Add arch and cgo to the matrix. By default, all OS build with amd64 arch, and cgo 0. 

For macos, add an additional build with:
- arch = arm64
- cgo = 1