### PR TITLE
Disable macos dns resolver

### DIFF
--- a/internal/helper/http.go
+++ b/internal/helper/http.go
@@ -88,6 +88,10 @@ func HttpNewRequestWrapper(method, url string, body io.Reader) (*http.Request, e
 }
 
 func ResolveUrl(url string) (string, bool) {
+	// disable mac os dns resolver
+	// TODO: remove this function, when the testing of macosx resolver is done
+	return url, false
+
 	if runtime.GOOS != "darwin" {
 		return url, false
 	}


### PR DESCRIPTION
Temporarily disable the dns resolver for macos. As we now have a matrix build which can build the macos version with CGO_ENABLED=1