### PR TITLE
Use golang built-in template engine

### DIFF
--- a/internal/command/default-command_test.go
+++ b/internal/command/default-command_test.go
@@ -154,7 +154,11 @@ func TestLegacyVariableInterpolation(t *testing.T) {
 		PkgDir:              "/tmp/test/root",
 	}
 
-	assert.Equal(t, fmt.Sprintf("/tmp/test/root/%s/test", runtime.GOOS), cmd.interpolateCmd())
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, fmt.Sprintf("/tmp/test/root/%s/test.exe", runtime.GOOS), cmd.interpolateCmd())
+	} else {
+		assert.Equal(t, fmt.Sprintf("/tmp/test/root/%s/test", runtime.GOOS), cmd.interpolateCmd())
+	}
 }
 
 func TestVariableRender(t *testing.T) {


### PR DESCRIPTION
Use golang built-in template engine to interpolate variables in command and arguments.
For now we still keep the legacy system.

fix #23 