### PR TITLE
Fix the issue https://github.com/criteo/command-launcher/issues/28

### DIFF
--- a/internal/gvault/file-vault_test.go
+++ b/internal/gvault/file-vault_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestVault_Init(t *testing.T) {
+	t.Setenv("CDT_VAULT_SECRET", "very_secret")
+
 	_, err := CreateVault("unit-test")
 	if err != nil {
 		t.Error(err)
@@ -13,6 +15,8 @@ func TestVault_Init(t *testing.T) {
 }
 
 func TestVault_WriteRead(t *testing.T) {
+	t.Setenv("CDT_VAULT_SECRET", "very_secret")
+
 	fv, err := CreateVault("unit-test")
 	if err != nil {
 		t.Error(err)
@@ -34,6 +38,8 @@ func TestVault_WriteRead(t *testing.T) {
 }
 
 func TestVault_MultiWriteRead(t *testing.T) {
+	t.Setenv("CDT_VAULT_SECRET", "very_secret")
+
 	fv, err := CreateVault("unit-test")
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
To run tests on any kind of workstation, the env var should be defined to avoid error message