### PR TITLE
Sort config output

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/criteo/command-launcher/internal/config"
@@ -28,8 +29,9 @@ func AddConfigCmd(rootCmd *cobra.Command, appCtx context.LauncherContext) {
 			// list all configs
 			if len(args) == 0 {
 				settings := viper.AllSettings()
-				for k, v := range settings {
-					fmt.Printf("%-40v: %v\n", k, v)
+				printableSettings := printableSettingsInOrder(settings)
+				for _, line := range printableSettings {
+					fmt.Println(line)
 				}
 			}
 
@@ -67,4 +69,20 @@ func AddConfigCmd(rootCmd *cobra.Command, appCtx context.LauncherContext) {
 		},
 	}
 	rootCmd.AddCommand(configCmd)
+}
+
+// get printable settings in alphabet order
+func printableSettingsInOrder(settings map[string]interface{}) []string {
+	sorted := []string{}
+	keys := []string{}
+	for k := range settings {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+	for _, k := range keys {
+		sorted = append(sorted, fmt.Sprintf("%-40v: %v", k, settings[k]))
+	}
+
+	return sorted
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintableSettings(t *testing.T) {
+	settings := map[string]interface{}{
+		"key 1": "123",
+		"key 0": "345",
+		"abc":   "efg",
+	}
+
+	printable := printableSettingsInOrder(settings)
+
+	assert.Equal(t, 3, len(printable))
+	assert.Equal(t, "abc                                     : efg", printable[0])
+	assert.Equal(t, "key 0                                   : 345", printable[1])
+	assert.Equal(t, "key 1                                   : 123", printable[2])
+}


### PR DESCRIPTION
Golang by default doesn't guarantee the order of a map. This makes the output config inconstant. Each run returns different order. 

This review fixes it by sorting the config with key.