### PR TITLE
Improve remote config load

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,7 +127,7 @@ func initCmdUpdater() {
 		CmdRepositoryBaseUrl: viper.GetString(config.COMMAND_REPOSITORY_BASE_URL_KEY),
 		User:                 rootCtxt.user,
 		Timeout:              viper.GetDuration(config.SELF_UPDATE_TIMEOUT_KEY),
-		EnableCI:             viper.GetBool(config.ENABLE_CI_KEY),
+		EnableCI:             viper.GetBool(config.CI_ENABLED_KEY),
 		PackageLockFile:      viper.GetString(config.PACKAGE_LOCK_FILE_KEY),
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -62,7 +62,7 @@ Check the update of %s and its commands.
 
 			if updateFlags.Package {
 				console.Highlight("checking available package updates ...")
-				enableCI := viper.GetBool(config.ENABLE_CI_KEY)
+				enableCI := viper.GetBool(config.CI_ENABLED_KEY)
 				packageLockFile := viper.GetString(config.PACKAGE_LOCK_FILE_KEY)
 				if enableCI {
 					fmt.Printf("CI mode enabled, load package lock file: %s\n", packageLockFile)

--- a/examples/remote-config/remote_config.json
+++ b/examples/remote-config/remote_config.json
@@ -1,4 +1,4 @@
 {
   "command_repository_base_url": "https://raw.githubusercontent.com/criteo/command-launcher/update-command/test/remote-repo",
-  "enable_ci": true
+  "ci_enabled": true
 }

--- a/internal/command/default-command_test.go
+++ b/internal/command/default-command_test.go
@@ -256,3 +256,29 @@ func TestVariableRenderError(t *testing.T) {
 
 	assert.Equal(t, "{{.Root}}/{{.Os}}/test{{.NonExistKey}}", cmd.interpolateCmd())
 }
+
+func TestInterpolate(t *testing.T) {
+	cmd := DefaultCommand{
+		CmdName:             "test",
+		CmdCategory:         "",
+		CmdType:             "executable",
+		CmdGroup:            "",
+		CmdShortDescription: "test command",
+		CmdLongDescription:  "test command - long description",
+		CmdExecutable:       "#CACHE#/#OS#/#ARCH#/test#EXT#",
+		CmdArguments:        []string{"-l", "-a", "#SCRIPT#"},
+		CmdDocFile:          "",
+		CmdDocLink:          "",
+		CmdValidArgs:        nil,
+		CmdValidArgsCmd:     nil,
+		CmdRequiredFlags:    nil,
+		CmdFlagValuesCmd:    nil,
+		PkgDir:              "/tmp/test/root",
+	}
+
+	assert.Equal(t, ".bat", cmd.doInterpolate("windows", "x64", "#SCRIPT_EXT#"))
+	assert.Equal(t, "", cmd.doInterpolate("linux", "x64", "#SCRIPT_EXT#"))
+	assert.Equal(t, "test.bat", cmd.doInterpolate("windows", "x64", "#SCRIPT#"))
+	assert.Equal(t, "test", cmd.doInterpolate("linux", "x64", "#SCRIPT#"))
+	assert.Equal(t, "/tmp/test/root/windows/x64/test.exe", cmd.doInterpolate("windows", "x64", "#CACHE#/#OS#/#ARCH#/test#EXT#"))
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -23,7 +23,7 @@ const (
 	METRIC_GRAPHITE_HOST_KEY             = "METRIC_GRAPHITE_HOST"
 	DEBUG_FLAGS_KEY                      = "DEBUG_FLAGS"
 	DROPIN_FOLDER_KEY                    = "DROPIN_FOLDER"
-	ENABLE_CI_KEY                        = "ENABLE_CI"
+	CI_ENABLED_KEY                       = "CI_ENABLED"
 	PACKAGE_LOCK_FILE_KEY                = "PACKAGE_LOCK_FILE"
 )
 
@@ -43,7 +43,7 @@ func init() {
 		METRIC_GRAPHITE_HOST_KEY,
 		DEBUG_FLAGS_KEY,
 		DROPIN_FOLDER_KEY,
-		ENABLE_CI_KEY,
+		CI_ENABLED_KEY,
 		PACKAGE_LOCK_FILE_KEY,
 	)
 }
@@ -77,7 +77,7 @@ func SetSettingValue(key string, value string) error {
 		return setStringConfig(upperKey, value)
 	case DROPIN_FOLDER_KEY:
 		return setStringConfig(upperKey, value)
-	case ENABLE_CI_KEY:
+	case CI_ENABLED_KEY:
 		return setBooleanConfig(upperKey, value)
 	case PACKAGE_LOCK_FILE_KEY:
 		return setStringConfig(upperKey, value)


### PR DESCRIPTION
- remote config load is based on time now. By defaut, once per 24 hours
- introduce remote_config_check_cycle to config the remote config check
  period
- introduce remote_config_check_time to indicate next remote check time
- rename config enable_ci to ci_enabled

- patch two new variables from upstream repo:
- variable #SCRIPT# is mapped to the command name with extension .bat in windows, .sh in linux
- variable #SCRIPT_EXT# is mapped to .bat in windows, .sh in linux