### PR TITLE
Custom auto complete directive

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -323,7 +323,17 @@ func addCommands(groups []command.Command, executables []command.Command) {
 				parts := strings.Split(output, "\n")
 				if len(parts) > 0 {
 					if strings.HasPrefix(parts[0], "#") { // skip the first control line, for further controls
-						return parts[1:], cobra.ShellCompDirectiveNoFileComp
+						// the first line starting with # is the control line, it controls the completion behavior when the return body is empty
+						shellDirective := cobra.ShellCompDirectiveNoFileComp
+						switch strings.TrimSpace(strings.TrimLeft(parts[0], "#")) {
+						case "dir-completion-only":
+							shellDirective = cobra.ShellCompDirectiveFilterDirs
+						case "default":
+							shellDirective = cobra.ShellCompDirectiveDefault
+						case "no-file-completion":
+							shellDirective = cobra.ShellCompDirectiveNoFileComp
+						}
+						return parts[1:], shellDirective
 					}
 					return parts, cobra.ShellCompDirectiveNoFileComp
 				}
@@ -331,7 +341,7 @@ func addCommands(groups []command.Command, executables []command.Command) {
 			if len(validArgs) > 0 {
 				return validArgs, cobra.ShellCompDirectiveNoFileComp
 			}
-			return []string{}, cobra.ShellCompDirectiveNoFileComp
+			return []string{}, cobra.ShellCompDirectiveDefault
 		}
 
 		if v.Group() == "" {


### PR DESCRIPTION
Auto-completion commands could control the auto-complete behavior, by adding a control line at the very beginning in the output. (with a prefix #)
- dir-completion-only: will let cdt complete with the directories
- default: will let cdt complete with the shell's defaut behavior
- no-file-completion: will disable the file completion