### PR TITLE
fix version comparison & sorting

### DIFF
--- a/cmd/remote/version.go
+++ b/cmd/remote/version.go
@@ -51,15 +51,16 @@ func (version defaultVersion) String() string {
 }
 
 func Less(l defaultVersion, r defaultVersion) bool {
-	if l.Major < r.Major {
-		return true
-	} else if l.Minor < r.Minor {
-		return true
-	} else if l.Patch < r.Patch {
-		return true
+	lseg := [3]int{l.Major, l.Minor, l.Patch}
+	rseg := [3]int{r.Major, r.Minor, r.Patch}
+	for i := 0; i < 3; i++ {
+		if lseg[i] != rseg[i] {
+			return lseg[i] < rseg[i]
+		}
 	}
 
-	return false
+	// If segments are equal, then compare the prerelease info
+	return l.Tag < r.Tag
 }
 
 func IsVersionSmaller(v1 string, v2 string) bool {


### PR DESCRIPTION
Version comparison doesn't handle all the cases properly.
For example, Less(1.1.0, 1.0.1) returns true but should return false.

Also compare prerelease info when semver segments are equal