### PR TITLE
🐛 Fix ScriptExtension manifest placeholder

### DIFF
--- a/internal/command/default-command.go
+++ b/internal/command/default-command.go
@@ -434,7 +434,7 @@ func (cmd *DefaultCommand) script_ext(os string) string {
 	if os == "windows" {
 		return ".bat"
 	}
-	return ""
+	return ".sh"
 }
 
 func (cmd *DefaultCommand) interpolate(text string) string {

--- a/internal/command/default-command_test.go
+++ b/internal/command/default-command_test.go
@@ -219,7 +219,7 @@ func TestInterpolate(t *testing.T) {
 	cmd.CmdArguments = []string{"-l", "-a", "#SCRIPT#"}
 
 	assert.Equal(t, ".bat", cmd.doInterpolate("windows", "x64", "#SCRIPT_EXT#"))
-	assert.Equal(t, "", cmd.doInterpolate("linux", "x64", "#SCRIPT_EXT#"))
+	assert.Equal(t, ".sh", cmd.doInterpolate("linux", "x64", "#SCRIPT_EXT#"))
 	assert.Equal(t, "test.bat", cmd.doInterpolate("windows", "x64", "#SCRIPT#"))
 	assert.Equal(t, "test.sh", cmd.doInterpolate("linux", "x64", "#SCRIPT#"))
 	assert.Equal(t, "/tmp/test/root/windows/x64/test.exe", cmd.doInterpolate("windows", "x64", "#CACHE#/#OS#/#ARCH#/test#EXT#"))

--- a/internal/command/default-command_test.go
+++ b/internal/command/default-command_test.go
@@ -169,7 +169,7 @@ func TestConditionalScriptRender(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		assert.Equal(t, "test.bat", cmd.interpolateCmd())
 	} else {
-		assert.Equal(t, "test", cmd.interpolateCmd())
+		assert.Equal(t, "test.sh", cmd.interpolateCmd())
 	}
 }
 
@@ -191,7 +191,7 @@ func TestConditionalScriptExtensionRender(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		assert.Equal(t, "test.bat", cmd.interpolateCmd())
 	} else {
-		assert.Equal(t, "test", cmd.interpolateCmd())
+		assert.Equal(t, "test.sh", cmd.interpolateCmd())
 	}
 }
 
@@ -221,7 +221,7 @@ func TestInterpolate(t *testing.T) {
 	assert.Equal(t, ".bat", cmd.doInterpolate("windows", "x64", "#SCRIPT_EXT#"))
 	assert.Equal(t, "", cmd.doInterpolate("linux", "x64", "#SCRIPT_EXT#"))
 	assert.Equal(t, "test.bat", cmd.doInterpolate("windows", "x64", "#SCRIPT#"))
-	assert.Equal(t, "test", cmd.doInterpolate("linux", "x64", "#SCRIPT#"))
+	assert.Equal(t, "test.sh", cmd.doInterpolate("linux", "x64", "#SCRIPT#"))
 	assert.Equal(t, "/tmp/test/root/windows/x64/test.exe", cmd.doInterpolate("windows", "x64", "#CACHE#/#OS#/#ARCH#/test#EXT#"))
 }
 


### PR DESCRIPTION
Documentation says either .bat or .sh according to OS, right now it's .bat or empty.