### PR TITLE
Extend login hook credentials

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -82,7 +82,7 @@ The credential will be stored in your system vault.`, appCtx.PasswordEnvVar()),
 			// call system login hook if defined
 			if loginHook != nil {
 				log.Debug("calling login system hook")
-				_, hookOutput, err := loginHook.ExecuteWithOutput([]string{}, username, passwd)
+				_, hookOutput, err := loginHook.ExecuteWithOutput(os.Environ(), username, passwd)
 				if err != nil {
 					return err
 				}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -26,4 +26,7 @@ type LauncherContext interface {
 	RemoteConfigurationUrlEnvVar() string
 
 	CmdPackageDirEnvVar() string
+
+	/* General function to get a environment variable name with prefix conventions */
+	EnvVarName(name string) string
 }

--- a/internal/context/default-context.go
+++ b/internal/context/default-context.go
@@ -47,42 +47,42 @@ func (ctx *defaultContext) AppDirname() string {
 }
 
 func (ctx *defaultContext) AppHomeEnvVar() string {
-	return ctx.envVarName("HOME")
+	return ctx.EnvVarName("HOME")
 }
 
 func (ctx *defaultContext) UsernameEnvVar() string {
-	return ctx.envVarName("USERNAME")
+	return ctx.EnvVarName("USERNAME")
 }
 
 func (ctx *defaultContext) PasswordEnvVar() string {
-	return ctx.envVarName("PASSWORD")
+	return ctx.EnvVarName("PASSWORD")
 }
 
 func (ctx *defaultContext) AuthTokenEnvVar() string {
-	return ctx.envVarName("AUTH_TOKEN")
+	return ctx.EnvVarName("AUTH_TOKEN")
 }
 
 func (ctx *defaultContext) LogLevelEnvVar() string {
-	return ctx.envVarName("LOG_LEVEL")
+	return ctx.EnvVarName("LOG_LEVEL")
 }
 
 func (ctx *defaultContext) DebugFlagsEnvVar() string {
-	return ctx.envVarName("DEBUG_FLAGS")
+	return ctx.EnvVarName("DEBUG_FLAGS")
 }
 
 func (ctx *defaultContext) ConfigurationFileEnvVar() string {
-	return ctx.envVarName("CONFIG_FILE")
+	return ctx.EnvVarName("CONFIG_FILE")
 }
 
 func (ctx *defaultContext) RemoteConfigurationUrlEnvVar() string {
-	return ctx.envVarName("REMOTE_CONFIG_URL")
+	return ctx.EnvVarName("REMOTE_CONFIG_URL")
 }
 
 func (ctx *defaultContext) CmdPackageDirEnvVar() string {
-	return ctx.envVarName("PACKAGE_DIR")
+	return ctx.EnvVarName("PACKAGE_DIR")
 }
 
-func (ctx *defaultContext) envVarName(name string) string {
+func (ctx *defaultContext) EnvVarName(name string) string {
 	return fmt.Sprintf("%s_%s", ctx.prefix(), name)
 }
 

--- a/internal/frontend/default-frontend.go
+++ b/internal/frontend/default-frontend.go
@@ -153,8 +153,8 @@ func (self *defaultFrontend) addExecutableCommands() {
 
 		cmd.ValidArgsFunction = func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(validArgsCmd) > 0 {
-	      var originalArgs = args
-        if checkFlags {
+				var originalArgs = args
+				if checkFlags {
 					c.LocalFlags().VisitAll(func(flag *pflag.Flag) {
 						switch flag.Value.Type() {
 						case "bool":
@@ -472,6 +472,14 @@ func (self *defaultFrontend) getCmdEnvContext(envVars []string, consents []strin
 				debugFlags,
 				viper.GetString(config.DEBUG_FLAGS_KEY),
 			))
+		default:
+			value, err := helper.GetSecret(strings.ToLower(item))
+			if err != nil {
+				value = ""
+			}
+			if value != "" {
+				vars = append(vars, fmt.Sprintf("%s=%s", self.appCtx.EnvVarName(item), value))
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit makes the login command store any credential key-value pairs returned from the login hook. It will enable the possibility to store different tokens in enterprise environments, e.g., one token for confluence, one token for some homemade services with custom authentication, and one JWT for other SSO-enabled services