### PR TITLE
Filter auto complete options

### DIFF
--- a/internal/frontend/default-frontend.go
+++ b/internal/frontend/default-frontend.go
@@ -173,8 +173,15 @@ func (self *defaultFrontend) addExecutableCommands() {
 					return []string{}, cobra.ShellCompDirectiveNoFileComp
 				}
 				parts := strings.Split(output, "\n")
-				if len(parts) > 0 {
-					if strings.HasPrefix(parts[0], "#") { // skip the first control line, for further controls
+				// filter the parts that starts with toComplete
+				filteredParts := []string{}
+				for idx, p := range parts {
+					if strings.HasPrefix(p, toComplete) || (idx == 0 && strings.HasPrefix(p, "#")) {
+						filteredParts = append(filteredParts, p)
+					}
+				}
+				if len(filteredParts) > 0 {
+					if strings.HasPrefix(filteredParts[0], "#") { // skip the first control line, for further controls
 						// the first line starting with # is the control line, it controls the completion behavior when the return body is empty
 						shellDirective := cobra.ShellCompDirectiveNoFileComp
 						switch strings.TrimSpace(strings.TrimLeft(parts[0], "#")) {
@@ -185,9 +192,9 @@ func (self *defaultFrontend) addExecutableCommands() {
 						case "no-file-completion":
 							shellDirective = cobra.ShellCompDirectiveNoFileComp
 						}
-						return parts[1:], shellDirective
+						return filteredParts[1:], shellDirective
 					}
-					return parts, cobra.ShellCompDirectiveNoFileComp
+					return filteredParts, cobra.ShellCompDirectiveNoFileComp
 				}
 			}
 			if len(validArgs) > 0 {

--- a/internal/frontend/default-frontend.go
+++ b/internal/frontend/default-frontend.go
@@ -168,7 +168,7 @@ func (self *defaultFrontend) addExecutableCommands() {
 						}
 					})
 				}
-				output, err := self.executeValidArgsOfCommand(group, name, originalArgs)
+				output, err := self.executeValidArgsOfCommand(group, name, originalArgs, toComplete)
 				if err != nil {
 					return []string{}, cobra.ShellCompDirectiveNoFileComp
 				}
@@ -288,13 +288,15 @@ func (self *defaultFrontend) executeCommand(group, name string, args []string, i
 }
 
 // execute the valid args command of the cdt command
-func (self *defaultFrontend) executeValidArgsOfCommand(group, name string, args []string) (string, error) {
+func (self *defaultFrontend) executeValidArgsOfCommand(group, name string, args []string, toComplete string) (string, error) {
 	iCmd, err := self.getExecutableCommand(group, name)
 	if err != nil {
 		return "", err
 	}
 
-	envCtx := self.getCmdEnvContext([]string{}, []string{})
+	envCtx := self.getCmdEnvContext([]string{
+		fmt.Sprintf("%s=%s", self.appCtx.EnvVarName("TO_COMPLETE"), toComplete),
+	}, []string{})
 
 	_, output, err := iCmd.ExecuteValidArgsCmd(envCtx, args...)
 	if err != nil {

--- a/test/integration/test-auto-complete.sh
+++ b/test/integration/test-auto-complete.sh
@@ -52,6 +52,30 @@ else
   exit 1
 fi
 
+echo "> test dynamic argument auto-complete with prefix filter"
+RESULT=$($CL_PATH __complete greeting saybonjour Jo)
+echo "$RESULT" | grep -q "John"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should auto-complete dynamic arguments"
+  exit 1
+fi
+echo "$RESULT" | grep -q "Kate"
+if [ $? -eq 0 ]; then
+  echo "KO - should only return options starts with the prefix"
+  exit 1
+else
+  echo "OK"
+fi
+echo "$RESULT" | grep -q "Jo$"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should successfully inject TO_COMPLETE envrionment variable"
+  exit 1
+fi
+
 echo "> test flag name auto-complete"
 RESULT=$($CL_PATH __complete bonjour -)
 echo "$RESULT" | grep -q "\-\-lang"

--- a/test/packages-src/bonjour/auto-complete.bat
+++ b/test/packages-src/bonjour/auto-complete.bat
@@ -1,5 +1,7 @@
 
 ECHO %*
 
+ECHO %CL_TO_COMPLETE%
+
 ECHO John
 ECHO Kate

--- a/test/packages-src/bonjour/auto-complete.sh
+++ b/test/packages-src/bonjour/auto-complete.sh
@@ -3,6 +3,7 @@
 # first line print all the arguments to this script to check if all necessary arguments are passed to it
 echo "$@"
 
+echo $CL_TO_COMPLETE
 
 echo "John"
 echo "Kate"

--- a/test/packages-src/bonjour/manifest.mf
+++ b/test/packages-src/bonjour/manifest.mf
@@ -38,7 +38,15 @@
       "executable": "{{.PackageDir}}/bonjour.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}",
       "args": [],
       "validArgsCmd": [ "{{.PackageDir}}/auto-complete.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}" ]
+    },
+    {
+      "name": "saybonjour2",
+      "type": "executable",
+      "group": "greeting",
+      "short": "print bonjour from command launcher",
+      "executable": "{{.PackageDir}}/bonjour.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}",
+      "args": [],
+      "validArgsCmd": [ "{{.PackageDir}}/auto-complete.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}" ]
     }
-
   ]
 }

--- a/test/packages-src/bonjour/manifest.mf
+++ b/test/packages-src/bonjour/manifest.mf
@@ -38,15 +38,6 @@
       "executable": "{{.PackageDir}}/bonjour.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}",
       "args": [],
       "validArgsCmd": [ "{{.PackageDir}}/auto-complete.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}" ]
-    },
-    {
-      "name": "saybonjour2",
-      "type": "executable",
-      "group": "greeting",
-      "short": "print bonjour from command launcher",
-      "executable": "{{.PackageDir}}/bonjour.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}",
-      "args": [],
-      "validArgsCmd": [ "{{.PackageDir}}/auto-complete.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}" ]
     }
   ]
 }


### PR DESCRIPTION
Filter the auto-complete options with the to-complete prefix string. This will improve the performance when dynamic options have lots of entries.