### PR TITLE
[NEW] Group top level commands by registry

### DIFF
--- a/gh-pages/content/en/docs/overview/config.md
+++ b/gh-pages/content/en/docs/overview/config.md
@@ -45,6 +45,7 @@ toc: true
 | verify_package_signature         | bool     | whether to verify the package signature during package installation (will be available in 1.8)                                |
 | extra_remotes                    | map      | extra remote registry configurations, see extra remote configuration  (available 1.8+)                                        |
 | enable_package_setup_hook        | bool     | call setup hook after a new version of package is installed (available 1.9+)                                                  |
+| group_help_by_registry           | bool     | group help by registry, default true (available 1.13+)                                                                        |
 
 ### extra remote configuration
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -114,6 +114,9 @@ func setDefaultConfig() {
 
 	viper.SetDefault(EXTRA_REMOTES_KEY, []map[string]string{})
 	viper.SetDefault(ENABLE_PACKAGE_SETUP_HOOK_KEY, false)
+
+	// by default, group the top level command by registry in the help message
+	viper.SetDefault(GROUP_HELP_BY_REGISTRY_KEY, true)
 }
 
 func initDefaultConfigFile() {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -37,6 +37,7 @@ const (
 	EXTRA_REMOTE_REPOSITORY_DIR_KEY      = "REPOSITORY_DIR"
 	EXTRA_REMOTE_SYNC_POLICY_KEY         = "SYNC_POLICY"
 	ENABLE_PACKAGE_SETUP_HOOK_KEY        = "ENABLE_PACKAGE_SETUP_HOOK"
+	GROUP_HELP_BY_REGISTRY_KEY           = "GROUP_HELP_BY_REGISTRY"
 
 	// internal commands are the commands with start partition number > INTERNAL_START_PARTITION
 	INTERNAL_COMMAND_ENABLED_KEY = "INTERNAL_COMMAND_ENABLED"
@@ -77,6 +78,7 @@ func init() {
 		SYSTEM_PACKAGE_KEY,
 		SYSTEM_PACKAGE_PUBLIC_KEY_FILE_KEY,
 		ENABLE_PACKAGE_SETUP_HOOK_KEY,
+		GROUP_HELP_BY_REGISTRY_KEY,
 	)
 }
 
@@ -132,6 +134,8 @@ func SetSettingValue(key string, value string) error {
 	case VERIFY_PACKAGE_SIGNATURE_KEY:
 		return setBooleanConfig(upperKey, value)
 	case ENABLE_PACKAGE_SETUP_HOOK_KEY:
+		return setBooleanConfig(upperKey, value)
+	case GROUP_HELP_BY_REGISTRY_KEY:
 		return setBooleanConfig(upperKey, value)
 	}
 

--- a/test/integration/test-basic.sh
+++ b/test/integration/test-basic.sh
@@ -48,3 +48,38 @@ else
   echo "KO - hello command shouldn't exist"
   exit 1
 fi
+
+##
+# test help message
+##
+
+# clean up the dropin folder
+rm -rf $CL_HOME/dropins
+mkdir -p $CL_HOME/dropins
+
+# copy the example to the dropin folder for the test
+cp -R $SCRIPT_DIR/../packages-src/bonjour $CL_HOME/dropins
+
+echo "> test group help message"
+RESULT=$($CL_PATH)
+echo "$RESULT" | grep -q "Commands from 'dropin' registry"
+if [ $? -eq 0 ]; then
+  # ok
+  echo "OK"
+else
+  echo "KO - should group help message by registry"
+  exit 1
+fi
+
+echo "> test help message without group"
+# set group_help_by_registry to false
+$CL_PATH config group_help_by_registry false
+# run command launcher to show the help message
+RESULT=$($CL_PATH)
+echo "$RESULT" | grep -q "Commands from 'dropin' registry"
+if [ $? -eq 0 ]; then
+  echo "KO - should group help message by registry"
+  exit 1
+else
+  echo "OK"
+fi

--- a/test/integration/test-config.sh
+++ b/test/integration/test-config.sh
@@ -40,3 +40,12 @@ else
   exit 1
 fi
 
+echo "> test group_help_by_registry config exist, and default true"
+RESULT=$($OUTPUT_DIR/cl config --json)
+VALUE=$(echo "$RESULT" | jq -r '.group_help_by_registry')
+if [ $VALUE == "true" ]; then
+  echo "OK"
+else
+  echo "KO - incorrect config value"
+  exit 1
+fi


### PR DESCRIPTION
This will improve the situation mentioned in #138 

Tested the original idea of grouping top level commands by package, turns out the output message are grouped into too many fragments, which reduces the readability.

This PR only group the top-level commands by registry and it can be toggled by a new configuration item `group_help_by_registry` with default value `true`

Here is an example help:

```
Criteo Dev Toolkit - A command launcher 🚀 made with <3

Happy Coding!

Example:
  cdt --help

Usage:
  cdt [flags]
  cdt [command]

Commands from 'dropin' registry
  migration                                   Collection of tools for migration
  moab-report                                 Generate MOAB reports

Commands from 'default' registry
  code                                        help for the command code
  devenv                                      Manage development environment
  doc                                         generate documentation from sources
  hotfix                                      Create, review, and build hotfix from your terminal
  moab                                        Generic MOAB commands
  mozart                                      Help for the command mozart

Additional Commands:
  completion                                  Generate completion script
  config                                      Manage configurations
  help                                        Help about any command
  login                                       Login to use services
  package                                     Manage command launcher packages
  remote                                      Manage command launcher remotes
  rename                                      Rename installed command
  update                                      Update cdt, or its commands
  version                                     Print the version number of CDT command

Flags:
  -h, --help   help for cdt

Use "cdt [command] --help" for more information about a command.
```
