### PR TITLE
Prepare for release 1.14.0

### DIFF
--- a/gh-pages/content/en/docs/overview/config.md
+++ b/gh-pages/content/en/docs/overview/config.md
@@ -63,11 +63,11 @@ Each extra remote must have a unique name, it is used to identify the command as
 }
 ```
 
-| Config Name     | Type   | Description                                                                                                    |
-|-----------------|--------|----------------------------------------------------------------------------------------------------------------|
-| remote_base_url | string | the base url of the remote repository, it must contain a `/index.json` endpoint to list all available packages |
-| sync_policy     | string | how often the repository is synched from its remote, always, hourly, daily, weekly, or monthly                 |
-| repository_dir  | string | the absolute path of the local repository folder to keep the downloaded local packages                         |
+| Config Name     | Type   | Description                                                                                                                                                                |
+|-----------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| remote_base_url | string | the base url of the remote repository, it must contain a `/index.json` endpoint to list all available packages                                                             |
+| sync_policy     | string | how often the repository is synched from its remote. Possible value: always, hourly, daily, weekly, or monthly. (hourly, daily, weekly and monthly are supported in 1.14+) |
+| repository_dir  | string | the absolute path of the local repository folder to keep the downloaded local packages                                                                                     |
 
 > You don't need to manage these extra remote configurations by your self. Use the built-in `remote` command instead
 

--- a/gh-pages/content/en/docs/overview/resources.md
+++ b/gh-pages/content/en/docs/overview/resources.md
@@ -68,7 +68,7 @@ AUTH_TOKEN=${COLA_AUTH_TOKEN}
 | USERNAME          | Yes                  | the username collected from `login` command               |
 | PASSWORD          | Yes                  | the password collected from `login` command               |
 | AUTH_TOKEN        | Yes                  | the authentication token collected from `login` command   |
-| LOG_LEVEL         | Yes                  | the log level of command launcher                         |
-| DEBUG_FLAGS       | Yes                  | the debug flags defined in command launcher's config      |
+| LOG_LEVEL         | No                   | the log level of command launcher                         |
+| DEBUG_FLAGS       | No                   | the debug flags defined in command launcher's config      |
 | PACKAGE_DIR       | No                   | the absolute path to the package directory                |
 | FULL_COMMAND_NAME | No                   | the name of the command executed (includes app and group) |

--- a/internal/frontend/default-frontend.go
+++ b/internal/frontend/default-frontend.go
@@ -485,7 +485,7 @@ func parseFlagDefinition(line string) (string, string, string, string, string) {
 func (self *defaultFrontend) getCmdEnvContext(cmd command.Command, envVars []string, consents []string) []string {
 	vars := append([]string{}, envVars...)
 
-	/* append environment variables that requires consent */
+	/* append environment variables that require consent */
 	for _, item := range consents {
 		switch item {
 		case consent.USERNAME:
@@ -523,7 +523,7 @@ func (self *defaultFrontend) getCmdEnvContext(cmd command.Command, envVars []str
 		}
 	}
 
-	/* append environment variables that do not requires consent */
+	/* append environment variables that do not require consent */
 	// append log level from configuration
 	logLevel := viper.GetString(config.LOG_LEVEL_KEY)
 	vars = append(vars, fmt.Sprintf("%s=%s",

--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,16 @@
+1.14.0:
+  version: 1.14.0
+  releaseNotes: |
+    # ✨ New Features and Updates
+      # Extra remote registry now support different sync policies: hourly, daily, weekly, and monthly. For the first iteration, the sync_policy configuration can only be modified in the configuration file. A built-in command will be provided in the future release to manage these sync policies.
+      # LOG_LEVEL and DEBUG_FLAGS no longer requires user consent.
+    # 🐛 Bug Fixes
+      # built-in update command now take into account the extra remote registries, and respect the sync_policy configuration for each registry.
+    # 📝 Documentation Updates
+      # Update configuration documentation to reflect the new sync_policy configuration and user consent resources.
+  startPartition: 0
+  endPartition: 9
+
 1.13.0:
   version: 1.13.0
   releaseNotes: |


### PR DESCRIPTION
- Clean up the code and doc concerning LOG_LEVEL and DEBUG_FLAGS as in discussion here: https://github.com/criteo/command-launcher/discussions/145
- Update document to indicate the official support sync_policy options (hourly, daily, weekly, and monthly)