### PR TITLE
Review (linting) documentation

### DIFF
--- a/gh-pages/content/en/docs/overview/built-in-commands.md
+++ b/gh-pages/content/en/docs/overview/built-in-commands.md
@@ -175,4 +175,3 @@ cola rename --delete [command full name]
 ```
 
 Now you have to use its original name to call the command.
-

--- a/gh-pages/content/en/docs/overview/built-in-commands.md
+++ b/gh-pages/content/en/docs/overview/built-in-commands.md
@@ -16,17 +16,17 @@ toc: true
 
 ## config
 
-Get or set command launcher configuration.
+Get or set the Command Launcher configuration.
 
-Use `cola config` to list all configurations.
+Use `cola config` to list all configuration entries.
 
-Use `cola config [key]` to get one configuration.
+Use `cola config [key]` to get one configuration entry.
 
-Use `cola config [key] [value]` to set one configuration.
+Use `cola config [key] [value]` to set one configuration entry.
 
 ## completion
 
-setup auto completion. See help to get instructions:
+Set up auto completion. See help to get instructions:
 
 ```shell
 cola completion --help
@@ -34,15 +34,15 @@ cola completion --help
 
 ## login
 
-Store your credentials securely and pass them to managed commands when requested and under your agreements. More details see: [Managed resources](../resources)
+Store your credentials securely and pass them to managed commands when requested and under your agreements. For more details see: [Managed resources](../resources)
 
 ## update
 
-Check updates for command launcher and managed commands.
+Check updates for the Command Launcher and any managed commands.
 
 ## version
 
-Return command launcher version information.
+Return Command Launcher version information.
 
 ## package
 
@@ -50,7 +50,7 @@ A collection of commands to manage installed packages and commands
 
 ### package list
 
-List installed packages and commands
+List installed packages and commands.
 
 ```shell
 # list local installed packages
@@ -71,7 +71,7 @@ cola package list --remote
 
 ### package install
 
-Install a dropin package from a git repo or from a zip file
+Install a *dropin package* from a git repo or from a zip file.
 
 ```shell
 # install a dropin package from git repository
@@ -83,7 +83,7 @@ cola package install --file https://github.com/criteo/command-launcher/raw/main/
 
 ### package delete
 
-Remove a dropin package from the package name defined in manifest
+Remove a *dropin package* from the package name defined in the manifest.
 
 ```shell
 cola package delete command-launcher-example-package
@@ -91,7 +91,7 @@ cola package delete command-launcher-example-package
 
 ### package setup
 
-Manually trigger the package [setup hook](../manifest/#__setup__)
+Manually trigger the package [setup hook](../manifest/#__setup__).
 
 ```shell
 cola package setup command-launcher-example-package
@@ -129,13 +129,13 @@ cola delete myregistry
 
 ### rename
 
-Rename a command into a different name
+Rename a command into a different name.
 
-To avoid command conflicts, each command has a unique full name in form of `[name]@[group]@[package]@[repository]`, for group command and root level command, it's group is empty. For example: `hello@@my-package@dropin` is the full name of the command `hello` in `my-package` package, which can be found in the `dropin` repository.
+To avoid command conflicts, each command has a unique full name in the form of `[name]@[group]@[package]@[repository]`. For group commands and root level commands, their group is empty. For example: `hello@@my-package@dropin` is the full name of the command `hello` in `my-package` package, which can be found in the `dropin` repository.
 
 Usually, such command is launched through: `cola [group] [name]`. You can rename the group and the name of the command to a different name, so that you can call it through: `cola [new group] [new name]`
 
-To rename a command to a different name, use following commands:
+To rename a command to a different name, use the following commands:
 
 ```shell
 # To change the group name:
@@ -150,26 +150,29 @@ For example, you can rename the `hello` command to `bonjour` using following ren
 ```shell
 cola rename hello@@my-package@dropin bonjour
 
-# now call it from cola will trigger the original hello command
+# now calling it from cola will trigger the original hello command
 cola bonjour
 ```
-
-### rename --delete
-
-To delete a renamed command name
-
-```shell
-cola rename --delete [command full name]
-```
-
-Now you have to use its original name to call the command
 
 ### rename --list
 
 > available in 1.10.0+
 
-To list all renamed command
+List all renamed commands.
+
+The Command Launcher keeps track of all renamed commands. You can list all renamed commands using the following command:
 
 ```shell
 cola rename --list
 ```
+
+### rename --delete
+
+Delete a renamed command name, reverting back to the original name.
+
+```shell
+cola rename --delete [command full name]
+```
+
+Now you have to use its original name to call the command.
+

--- a/gh-pages/content/en/docs/overview/config.md
+++ b/gh-pages/content/en/docs/overview/config.md
@@ -69,14 +69,14 @@ Each extra remote must have a unique name, it is used to identify the command as
 | sync_policy     | string | how often the repository is synched from its remote. Possible value: always, hourly, daily, weekly, or monthly. (hourly, daily, weekly and monthly are supported in 1.14+) |
 | repository_dir  | string | the absolute path of the local repository folder to keep the downloaded local packages                                                                                     |
 
-> You don't need to manage these extra remote configurations by your self. Use the built-in `remote` command instead
+> You don't need to manage these extra remote configurations by yourself. Use the built-in `remote` command instead.
 
 ## Change configuration
 
-It is recommended to use the built-in `config` command to change the configurations. For duration type configurations, you can use `h`, `m`, and `s` to present hour, minute, and seconds. For example:
+It is recommended to use the built-in `config` command to change the configuration. For duration type configuration entries, you can use `h`, `m`, and `s` to represent hours, minutes, and seconds, respectively. For example:
 
 ```bash
 cola config user_consent_life 24h
 ```
 
-set the user consent life to 24 hours.
+will set the value of `user_consent_life` to 24 hours.

--- a/gh-pages/content/en/docs/overview/dropin.md
+++ b/gh-pages/content/en/docs/overview/dropin.md
@@ -16,28 +16,28 @@ toc: true
 
 ## What is dropin package? and why do I need it?
 
-A dropin package is a package that are not managed by the remote repository. It is only available on the developer's machine. It allows developers to integrate their own scripts/tools into command launcher to benefit the feature provided by the command launcher, for example, auto-complete, monitoring etc.
+A _dropin_ package is a package that is only available on the local machine, rather than managed by the remote repository. It allows developers to integrate their own scripts/tools into Command Launcher to benefit from the features provided by the command launcher, such as auto-complete, monitoring, etc.
 
-For example, you probably already has lots of shell scripts to maintain your infrastructure. Writing auto-completion for all these scripts is time consuming and it is difficult to remember which script doing what, and what parameters they accept. By writing a simple `manifest.mf` file, you can let command launcher to manage these scripts for you with auto-complete, secret management, and monitoring.
+For example, you probably already have lots of shell scripts to maintain your infrastructure. Writing auto-completion for all these scripts is time consuming and it is difficult to remember which script does what, and what parameters they accept. Writing a `manifest.mf` file is enough to let Command Launcher manage these scripts for you with auto-complete, secret management, and monitoring.
 
-Dropin package is also a good way for you to develop and test your command launcher package, as it follows the same structure as a regular command launcher package.
+A dropin package is also a good way for you to develop and test your Command Launcher package, as it follows the same structure as a regular package.
 
 ## How to create a dropin package?
 
-1. identify the dropins folder: run the following command:
+1. identify the _dropins folder_: run the following command:
 
     ```shell
     cola config dropin_folder
     ```
 
     If the dropin folder returned by the command doesn't exist, create it.
-1. create a package folder in the dropin folder, let's say, a package named `my-first-package`. You can named it whatever you want.
-1. add a `manifest.mf` in the newly created package folder, follow [MANIFEST](../manifest) guide to define your command in the manifest file. Note: you can copy your scripts in the package folder and use `{{.PackageDir}}` to reference the package location in your manifest file.
+1. create a package folder in the dropin folder, let's say, a package named `my-first-package`. You can name it whatever you want.
+1. add a `manifest.mf` file in the newly created package folder, follow the [MANIFEST](../manifest) guide to define your commands in this file. Note: you can copy your scripts in the package folder and use `{{.PackageDir}}` to reference the package location in your manifest file.
 1. run `cola` any time to test your command
 
 ## How to share a dropin package with others?
 
-A dropin package is simply a directory with manifest.mf in it, the best way to share a dropin package is to push it to a git repository and ask for others to clone it in their own dropin folder.
+A dropin package is simply a directory with `manifest.mf` file in it; the best way to share a dropin package is to push it to a git repository and ask others to clone it in their own dropin folder.
 
 Starting from 1.7.0, you can use the built-in `install` command to install a dropin package hosted in a git repository or a zip file:
 
@@ -45,12 +45,12 @@ Starting from 1.7.0, you can use the built-in `install` command to install a dro
 cola package install --git https://github.com/criteo/command-launcher-package-example
 ```
 
-If you uploaded your package to an http server as a zip file, you can install it with `cola install --file`
+If you uploaded your package to an HTTP server as a zip file, you can install it with `cola install --file`
 
 ```shell
 cola package install --file https://github.com/criteo/command-launcher/raw/main/examples/remote-repo/command-launcher-demo-1.0.0.pkg
 ```
 
-## How to update dropin package?
+## How to update a dropin package?
 
-For now, the command launcher does not update the dropin folder automatically, it is up to developers themselve to keep these dropin package up-to-date.
+Command Launcher does not currently update the dropin folder automatically, it is up to developers themselves to keep these dropin packages up-to-date.

--- a/gh-pages/content/en/docs/overview/introduction.md
+++ b/gh-pages/content/en/docs/overview/introduction.md
@@ -17,28 +17,30 @@ mermaid: true
 
 ## What is command launcher?
 
-Command launcher is a small footprint, rich feature CLI management tool for both enterprise and individual CLI developers. It eases the command line tool development by providing built-in common functionalities like: monitoring, progressive rollout, auto-completion, credential management, and more to your commands.
+Command launcher is a small-footprint, feature-rich CLI management tool for both enterprise and individual CLI developers. It eases the command line tool development by providing built-in common functionalities like: monitoring, progressive rollout, auto-completion, credential management, and more to your commands.
 
 ## Why a command launcher?
 
-At Criteo, we have many teams who provides command line applications for developers. These CLI providers repeatly handle the same features and functionalities for their CLI apps, such as auto-completion, credential management, release, delivery, monitoring, etc.
+At Criteo, we have many teams who provide command line applications for developers. These CLI providers repeatly handle the same features and functionalities for their CLI apps, such as auto-completion, credential management, release, delivery, monitoring, etc.
 
-On developer side, they have to manually download these tools to keep them up-to-date, it is difficult for them to discover available new tools. On the other hand, different developers have developed lots of similar handy scripts/tools by themselves without an easy way to share with others to avoid "re-inventing" the wheel.
+On the developer side, they have to manually download these tools and keep them up-to-date. It is also difficult for them to discover available new tools. On the other hand, different developers have developed lots of similar handy scripts/tools by themselves without an easy way to share with others to avoid "re-inventing" the wheel.
 
-To improve both developer and CLI provider's experience, we developed a command launcher to solve the above issues. It has built-in features like auto-completion, credential management, progressive roll-out, and monitoring, so that the CLI app provider can focus on the functionality of their CLI app. Developers only need to download the command launcher to access all these CLI apps. The command launcher will keep their CLI application up-to-date. The dropin feature allows developers to integrate their own scripts/tools into command launcher and share with others. These scripts and tools can also benefits from built-in features like auto-completion, and monitoring.
+To improve both developer and CLI provider's experience, we developed a command launcher to solve the above issues. It has built-in features like auto-completion, credential management, progressive roll-out, and monitoring, so that the CLI app provider can focus on the functionality of their CLI app. Developers only need to download the command launcher to access all these CLI apps. The command launcher will keep their CLI application up-to-date. The dropin feature allows developers to integrate their own scripts/tools into command launcher and share with others. These scripts and tools can also benefit from built-in features like auto-completion and monitoring.
 
 ## How it works?
 
-Command launcher is a small binary downloaded by developer in their development environment. CLI provider packages new commands or new version of command into a package, upload it to a remote repository, and update the package index of the repository. This process can be automated. More details about the remote repository, see [CLI Provider Guide](../provider-guide)
+Command Launcher is a small binary downloaded by a developer in their development environment. *CLI providers* package new commands or new versions of commands into a package, upload them to a remote repository, and update the package index of the repository. This process can be automated. For more details about the remote repository, see [CLI Provider Guide](../provider-guide)
 
-Developers can integrate their own commands into command launcher as a "dropin" package. These dropin package will be only accessible from the developers themselves. To share such commands see [Dropin Package](../dropin)
+Developers can integrate their own commands into Command Launcher as a "dropin" package. These dropin packages will be only accessible on the developer's machine. To share such commands see [Dropin Package](../dropin)
 
-Developers run command launcher to access these commands, for example, you have a command called `toto`, instead of run it directly from command line, you use `cl toto`, where `cl` is the binary name of the command launcher, you can name it anything suits you. Every time you execute command launcher, it will synchronize with the remote command, and propose available updates if exists.
+Developers run Command Launcher to access these commands. For example, if you have a command called `toto`, instead of running it directly from the command line, you use `cl toto`, where `cl` is the binary name of the Command Launcher (you can name it anything that suits you).
+
+Every time you run the Command Launcher, it will synchronize with the remote command, and propose updates if they are available.
 
 ```text
 
                            ┌──────────────────┐    Synch    ┌───────────────────────────┐
-            ┌──────────────│ command launcher │◄────────────│ Remote Command Repository │
+            ┌──────────────│ Command Launcher │◄────────────│ Remote Command Repository │
             │              └──────────────────┘             └───────────────────────────┘
             │                       │                                      │
             │            ┌──────────┼──────────┐              ┌────────────┼────────────┐
@@ -55,46 +57,46 @@ Developers run command launcher to access these commands, for example, you have 
 
 ## Features
 
-- **Small footprint**. Command launcher is around 10M, with no dependency to your OS.
-- **Technology agnostic**. It can launch commands implemented in any technology, and integrate to it with a simple manifest file.
-- **Auto-completion**. It supports auto-completion for all your commands installed by it.
-- **Auto-update**. Not only keeps itself but all its commands up-to-date.
-- **Credential management**. With the built-in login command, it securely passes user credential to your command.
+- **Small footprint**. Command Launcher is around 10M, with no dependency to your OS.
+- **Technology agnostic**. It can launch commands implemented in any technology, and integrate them with a simple manifest file.
+- **Auto-completion**. It will auto-complete the name of your commands out of the box, and their arguments if you provide the right information in the manifest file.
+- **Auto-update**. Command Launcher can keep itself and its command packages up to date.
+- **Credential management**. With the built-in `login` command, it securely passes user credentials to your commands.
 - **Progressive rollout**. Target a new version of command to a group of beta test users, and rollout progressively to all your users.
-- **Monitoring**. Built-in monitoring feature to monitor the usage your commands.
-- **Dropins**. Easy to intergrate your own command line scripts/tools by dropping your manifest in the "dropins" folder.
+- **Monitoring**. Built-in monitoring feature to monitor the usage of your commands.
+- **Dropins**. Easy to integrate your own command line scripts/tools by dropping your manifest in the "dropins" folder.
 
 ## Installation
 
-Pre-built binary can be downloaded from the release page. Unzip it, copy the binary into your PATH.
+A pre-built binary can be downloaded from the release page. Unzip it, and place the binary in a directory in your `PATH`.
 
-The two pre-built binaries are named `cola` (**Co**mmand **La**uncher) and `cdt` (**C**riteo **D**ev **T**oolkit), if you want to use a different name, you can pass your prefered name in the build. See build section below.
+The two pre-built binaries are named `cola` (**Co**mmand **La**uncher) and `cdt` (**C**riteo **D**ev **T**oolkit), if you want to use a different name, you can pass your preferred name in the build. See the *build* section below.
 
-## Build
+## Building
 
 Requirements: golang >= 1.17
 
-You can build the command launcher with your prefered name (in the example: `Criteo Developer Toolkit`, a.k.a `cdt`).
+You can build the command launcher with your preferred name (in the example: `Criteo Developer Toolkit`, a.k.a `cdt`).
 
 ```shell
 go build -o cdt -ldflags='-X main.version=dev -X main.appName=cdt -X "main.appLongName=Criteo Dev Toolkit"' main.go
 ```
 
-Or simply call the `build.sh` scripts
+Or simply call the `build.sh` script
 
 ```shell
 ./build.sh [version] [app name] [app long name]
 ```
 
-## Run tests
+## Running tests
 
-Run unit tests
+Run unit tests:
 
 ```shell
 go test -v ./...
 ```
 
-Run all integration tests
+Run all integration tests:
 
 ```shell
 ./test/integration.sh
@@ -106,7 +108,7 @@ You can run one integration test by specify the name of the integration test fil
 ./test/integration.sh test-remote
 ```
 
-## Release
+## Releasing
 
 Simply tag a commit with format 'x.y.z', and push it.
 
@@ -120,4 +122,4 @@ The supported release tag format:
 - \*.\*.\*
 - \*.\*.\*-\*
 
-Example: `1.0.0`, `1.0.1-preview`
+Examples: `1.0.0`, `1.0.1-preview`

--- a/gh-pages/content/en/docs/overview/manifest.md
+++ b/gh-pages/content/en/docs/overview/manifest.md
@@ -89,11 +89,11 @@ You must make sure your command's group and name combination is unique.
 
 There are three types of commands: `group`, `executable`, and `system`.
 
-* An `executable` command is meant to be executed. You must fill the `executable` and `args` fields of an executable command.
+- An `executable` command is meant to be executed. You must fill the `executable` and `args` fields of an executable command.
 
-* A `group` command is used to group executable commands. It does not run anything by itself.
+- A `group` command is used to group executable commands. It does not run anything by itself.
 
-* A `system` command is an executable command which extends some built-in Command Launcher functions. For more details see [system package](../system-package)
+- A `system` command is an executable command which extends some built-in Command Launcher functions. For more details see [system package](../system-package)
 
 ### group
 

--- a/gh-pages/content/en/docs/overview/manifest.md
+++ b/gh-pages/content/en/docs/overview/manifest.md
@@ -17,15 +17,15 @@ toc: true
 
 ## What is a manifest.mf file?
 
-A manifest.mf file is a file located at the root of your command launcher package. It describes the commands packaged in the zip file. When cola installs a package, it reads the manifest file and registers the commands in the manifest file.
+A `manifest.mf` file is a file located at the root of your Command Launcher package. It describes the commands packaged in the zip file. When cola installs a package, it reads the manifest file and registers the commands it finds described in it.
 
 ## Format of manifest.mf
 
-manifest.mf is in JSON or YAML format. It contains 3 fields:
+The `manifest.mf` file can be in either JSON or YAML format. It contains three top-level keys:
 
-- pkgName: a unique name of your package
-- version: the version of your package
-- cmds: a list of command definition, see command definition section
+- `pkgName`: a unique name of your package
+- `version`: the version of your package
+- `cmds`: a list of command definitions, see the _Command Definition_ section
 
 Here is an example
 
@@ -39,37 +39,39 @@ Here is an example
 
 ## Command Definition
 
-> Command launcher is implemented with [cobra](https://github.com/spf13/cobra). It follows the same command concepts:
->
-> Commands represent actions, Args are things and Flags are modifiers for those actions.
->
-> The best applications read like sentences when used, and as a result, users intuitively know how to interact with them.
->
-> The pattern to follow is APPNAME VERB NOUN --ADJECTIVE or APPNAME COMMAND ARG --FLAG.
->
-> Each package contains multiple command definitions. You can specify following definition for your command:
+Command Launcher is implemented with [cobra](https://github.com/spf13/cobra). It follows the same command concepts:
+
+_Commands_ represent actions, _Args_ are the objects of those actions and _Flags_ are modifiers for those actions.
+
+The best applications read like sentences when used and, as a result, users are more likely to intuitively know how to interact with them.
+
+The pattern to follow is `APPNAME VERB NOUN --ADJECTIVE` or `APPNAME COMMAND ARG --FLAG`.
+
+Each package can contain multiple command definitions.
+
+These are the properties available to define each command:
 
 ### Command properties list
 
-| Property           | Required           | Description                                                                                          |
-|--------------------|--------------------|------------------------------------------------------------------------------------------------------|
-| name               | yes                | the name of your command                                                                             |
-| type               | yes                | the type of the command, `group` or `executable`                                                     |
-| group              | no                 | the group of your command belongs to, default, command launcher root                                 |
-| short              | yes                | a short description of your command, it will be display in auto-complete options                     |
-| long               | no                 | a long description of your command                                                                   |
-| argsUsage          | no                 | custom the one line usage in help                                                                    |
-| examples           | no                 | a list of example entries                                                                            |
-| executable         | yes for executable | the executable to call when executing your command                                                   |
-| args               | no                 | the argument list to pass to the executable, command launcher arguments will be appended to the list |
-| validArgs          | no                 | the static list of options for auto-complete the arguments                                           |
-| validArgsCmd       | no                 | array of string, command to run to get the dynamic auto-complete options for arguments               |
-| requiredFlags      | no                 | the static list of options for the command flags (deprecated in 1.9)                                 |
-| flags              | no                 | the flag list (available in 1.9+)                                                                    |
-| exclusiveFlags     | no                 | group of exclusive flags (available in 1.9+)                                                         |
-| groupFlags         | no                 | group of grouped flags, which must be presented together (available in 1.9+)                         |
-| checkFlags         | no                 | whether check the flags defined in manifest before calling the command, default false                |
-| requestedResources | no                 | the resources that the command requested, ex, USERNAME, PASSWORD                                     |
+| Property           | Required           | Description                                                                                           |
+|--------------------|--------------------|-------------------------------------------------------------------------------------------------------|
+| name               | yes                | the name of your command                                                                              |
+| type               | yes                | the type of the command, `group` or `executable`                                                      |
+| group              | no                 | the group of your command belongs to. Default: Command Launcher root                                  |
+| short              | yes                | a short description of your command, it will be displayed in auto-complete options                    |
+| long               | no                 | a long description of your command                                                                    |
+| argsUsage          | no                 | customize the one-line usage in help output                                                           |
+| examples           | no                 | a list of example entries                                                                             |
+| executable         | yes for executable | the executable to call when running your command                                                      |
+| args               | no                 | the argument list to pass to the executable, Command Launcher arguments will be appended to this list |
+| validArgs          | no                 | the static list of options for auto-completing the arguments                                          |
+| validArgsCmd       | no                 | (array of strings) command to run to get the dynamic auto-complete options for arguments              |
+| requiredFlags      | no                 | the static list of options for the command flags (deprecated in 1.9)                                  |
+| flags              | no                 | the flag list (available in 1.9+)                                                                     |
+| exclusiveFlags     | no                 | group of exclusive flags (available in 1.9+)                                                          |
+| groupFlags         | no                 | group of grouped flags, which must be presented together (available in 1.9+)                          |
+| checkFlags         | no                 | whether to check the flags defined in manifest before calling the command. Default: false             |
+| requestedResources | no                 | the resources that the command requested, e.g., `USERNAME`, `PASSWORD`                                |
 
 ## Command properties
 
@@ -81,17 +83,17 @@ The name of the command. A user uses the group and the name of the command to ru
 cola {group} {name}
 ```
 
-You must make sure your command's group and name combination is unique
+You must make sure your command's group and name combination is unique.
 
 ### type
 
-There are three types of commands: `group`, `executable`, or `system`
+There are three types of commands: `group`, `executable`, and `system`.
 
-An `executable` type of command is meant to be executed. You must fill the `executable` and `args` fields of an executable command.
+* An `executable` command is meant to be executed. You must fill the `executable` and `args` fields of an executable command.
 
-A `group` type of command is used to group executable commands.
+* A `group` command is used to group executable commands. It does not run anything by itself.
 
-A `system` type of command is an executable command which extends the built-in command-launcher functions. More details see [system package](../system-package)
+* A `system` command is an executable command which extends some built-in Command Launcher functions. For more details see [system package](../system-package)
 
 ### group
 
@@ -101,13 +103,13 @@ The group of your command. A user uses the group and the name of your command to
 cola {group} {name}
 ```
 
-You must make sure your command's group and name combination is unique
+You must make sure your command's group and name combination is unique.
 
-To registry a command at the root level of command launcher, set `group` to empty string.
+To register a command at the root level of Command Launcher, set the `group` to an empty string.
 
-> Note: command launcher only supports one level of group, the "group" field of a "group" type command is ignored.
+> Note: command launcher only supports one level of grouping, the "group" field of a "group" type command is ignored.
 
-**Example**
+**Example:**
 
 ```json
 {
@@ -129,7 +131,7 @@ To registry a command at the root level of command launcher, set `group` to empt
 }
 ```
 
-The above manifest snippet registered a command: `cola infra reinstall`, when triggered, it will execute the `reinstall` binary located in the package's bin folder
+The above manifest snippet registered a command: `cola infra reinstall`. When triggered, it will execute the `reinstall` binary located in the package's `bin` folder
 
 ### short
 
@@ -137,18 +139,18 @@ The short description of the command. It is mostly used as the description in au
 
 ### long
 
-The long description of the command. In case your command doesn't support "-h" or "--help" flags, command launcher will generate one help command for you, and render your long description in the output.
+The long description of the command. In case your command doesn't support "-h" or "--help" flags, command launcher will generate one `help` command for you, and render your long description in the output.
 
 ### argsUsage
 
-Custom the one-line usage message. By default, command launcher will generate a one-line usage in the format of:
+Customize the one-line usage message. By default, Command Launcher will generate a one-line usage in the format of:
 
 ```text
 Usage:
   APP_NAME group command_name [flags]
 ```
 
-For some commands that accept multiple types of arguments, it would be nice to have a usage that show the different argument names and their orders. For example, for a command that accepts the 1st argument as country, and 2nd argument as city name, we can custom the usage message with following manifest:
+For some commands that accept multiple types of arguments, it would be nice to have a usage message that shows the different argument names and their order. For example, for a command that accepts a country as first argument, and a city as second argument, we can customize the usage message with the following manifest entry:
 
 ```json
 {
@@ -166,7 +168,7 @@ For some commands that accept multiple types of arguments, it would be nice to h
 }
 ```
 
-The help message looks like:
+The help message will then look like this:
 
 ```text
 Usage:
@@ -221,9 +223,11 @@ Example:
 
 ### executable
 
-The executable to call when your command is trigger from command launcher. You can inject predefined variables in the executable location string. More detail about the variables see [Manifest Variables](./VARIABLE.md)
+The executable to call when your command is triggered from Command Launcher.
 
-**Example**
+You can inject predefined variables in the executable location string. For details about those variables see [Manifest Variables](./VARIABLE.md)
+
+**Example:**
 
 ```json
 {
@@ -238,9 +242,9 @@ The executable to call when your command is trigger from command launcher. You c
 
 ### args
 
-The arguments that to be appended to the executable when the command is triggered. The other arguments passed from command launcher will be appeneded after these arguments that are defined in `args` field.
+The arguments that are to be appended to the executable when the command is triggered. The other arguments passed from Command Launcher will be appended after these arguments that are defined in the `args` field.
 
-**Example**
+**Example:**
 
 ```json
 {
@@ -257,7 +261,7 @@ The arguments that to be appended to the executable when the command is triggere
 }
 ```
 
-When we call this command from command launcher:
+When we call this command from Command Launcher:
 
 ```shell
 cola crawler --url https://example.com
@@ -269,13 +273,13 @@ It executes following command:
 java -jar {{package path}}/bin/crawler.jar --url https://example.com
 ```
 
-Note: you can use variables in `args` fields as well. See [Variables](./VARIABLE.md)
+> Note: you can use variables in `args` fields as well. See [Variables](./VARIABLE.md)
 
 ### validArgs
 
-A static list of the arguments for auto-complete.
+A static list of the arguments to offer when auto-completing the command.
 
-**Example**
+**Example:**
 
 ```json
 {
@@ -296,15 +300,17 @@ A static list of the arguments for auto-complete.
 }
 ```
 
-Once you have configured auto-complete for command launcher, the command described above will have auto-complete for its arguments.
+Once you have configured auto-complete for Command Launcher, the command described above will have auto-completion for its arguments.
 
-When you type: `[cola] city population [TAB]`, your shell will prompt options: `paris`, `rome`, and `london`
+When you type: `[cola] city population [TAB]`, your shell will prompt options: `paris`, `rome`, and `london`.
 
 ### validArgsCmd
 
-A command to execute to get the dynamic list of arguments.
+A command to execute to get the dynamic list of valid arguments for auto-completion.
 
-**Example**
+This command can take its own arguments and must be specified as an array of strings.
+
+**Example:**
 
 ```json
 {
@@ -332,20 +338,20 @@ More details see: [Auto-Complete](./AUTO_COMPLETE.md)
 
 > Available in 1.9+
 
-Define flags (options) of the command. Each flags could have the following properties
+Define flags (options) of the command. Each flag could have the following properties
 
-| Property  | Required | Description                                                                                         |
-|-----------|----------|-----------------------------------------------------------------------------------------------------|
-| name      | yes      | flag name                                                                                           |
-| short     | no       | flag short name, usually one letter                                                                 |
-| desc      | no       | flag description                                                                                    |
-| type      | no       | flag type, default "string", currently support "string" and bool"                                   |
-| default   | no       | flag default value, only available for string type, bool flag's default is always false             |
-| required  | no       | boolean, is the flag required, default false                                                        |
-| values    | no       | list of values for the flag for Auto-Complete. Available in 1.10.0+                                 |
-| valuesCmd | no       | list of string. The command to call to get available values for auto-complete. Available in 1.10.0+ |
+| Property  | Required | Description                                                                                          |
+|-----------|----------|------------------------------------------------------------------------------------------------------|
+| name      | yes      | flag name                                                                                            |
+| short     | no       | flag short name, usually one letter                                                                  |
+| desc      | no       | flag description                                                                                     |
+| type      | no       | flag type, default "string", currently supporting "string" and bool"                                 |
+| default   | no       | flag default value, only available for string type, bool flag's default is always false              |
+| required  | no       | boolean, is the flag required, default false                                                         |
+| values    | no       | list of values for the flag for Auto-Complete. Available in 1.10.0+                                  |
+| valuesCmd | no       | list of strings. The command to call to get available values for auto-complete. Available in 1.10.0+ |
 
-**Example**
+**Example:**
 
 ```json
 {
@@ -365,7 +371,7 @@ Define flags (options) of the command. Each flags could have the following prope
         {
           "name": "human",
           "short": "H",
-          "desc": "return the human readabe format",
+          "desc": "return the human readable format",
           "type": "bool"
         }
       ]
@@ -378,9 +384,9 @@ Define flags (options) of the command. Each flags could have the following prope
 
 > Available in 1.9+
 
-Declare two or more flags are mutually exclusive. For example, a flag `json` that outputs JSON format will be exclusive to the flag `text`, which outputs in plain text format.
+Declare two or more flags are mutually exclusive. For example, a flag `json` that outputs in JSON format will be exclusive to the flag `text`, which outputs in plain text format.
 
-**Example**
+**Example:**
 
 ```json
 {
@@ -400,7 +406,7 @@ Declare two or more flags are mutually exclusive. For example, a flag `json` tha
         {
           "name": "human",
           "short": "H",
-          "desc": "return the human readabe format",
+          "desc": "return the human readable format",
           "type": "bool"
         },
         {
@@ -424,7 +430,7 @@ Declare two or more flags are mutually exclusive. For example, a flag `json` tha
 
 Ensure that two or more flags are presented at the same time.
 
-**Example**
+**Example:**
 
 ```json
 {
@@ -460,9 +466,9 @@ Ensure that two or more flags are presented at the same time.
 
 > Deprecated in 1.9, see [flags](./#flags) property
 
-The static list of flags for your command
+The static list of flags for your command.
 
-**Example**
+**Example:**
 
 ```json
 {
@@ -498,7 +504,7 @@ The flag definition string uses `\t` to separate different fields. A complete fi
 | 4              | flag type          | optional, the flag type, one of string and bool. Default: string                                  |
 | 5              | flag default value | optional, the default value if not specified                                                      |
 
-Beside the complete form, it is also possible to have a short form:
+Besides the complete form, it is also possible to have a short form:
 
 1. only the full name: ex. "user-name"
 2. full name + description: ex. "user-name\t the user name"
@@ -506,25 +512,25 @@ Beside the complete form, it is also possible to have a short form:
 
 ### checkFlags
 
-Whether parse and check flags before execute the command. Default: false.
+Whether to parse and check flags before execute the command. Default: false.
 
-The `requiredFlags` (deprecated in 1.9), `flags`, `validArgs` and `validArgsCmd` are mainly used for auto completion. Command launcher will not parse the flag and arguments by default, it will simply pass through them to the callee command. In other words, in this case, it is the callee command's responsibility to parse the flags and arguments. This works fine when the command is implemented with languages that has advanced command line supports, like golang.
+The `requiredFlags` (deprecated in 1.9), `flags`, `validArgs` and `validArgsCmd` are mainly used for auto-completion. Command Launcher will not parse the flag and arguments by default, it will simply pass through them to the callee command. In other words, in this case, it is the callee command's responsibility to parse the flags and arguments. This works fine when the command is implemented with languages that have advanced command line support, like golang.
 
-For some cases, arguments parsing is difficult or has less support, for example, implementing the command in shell script. Enable `checkFlags` will allow command launcher to parse the arguments and catch errors. Further more, command launcher will pass the parsed flags and arguments to the callee command through environment variables:
+In other cases, argument parsing is difficult or has less support, for example, implementing the command in shell script. Enabling `checkFlags` will allow Command Launcher to parse the arguments and catch errors. Furthermore, Command Launcher will pass the parsed flags and arguments to the callee command through environment variables:
 
 - For flags: `COLA_FLAG_[FLAG_NAME]` ('-' is replaced with '_'). Example: flag `--user-name` is passed through environment variable `COLA_FLAG_USER_NAME`
 
-- For arguments: `COLA_ARG_[INDEX]` where the index starts from 1. Example: command `cola get-city-population France Paris` will get environment variable `COLA_ARG_1=France` and `COLA_ARG_2=Paris`. An additional environment variable `COLA_NARGS` (available in 1.9+) is available as well to get the number of arguments.
+- For arguments: `COLA_ARG_[INDEX]` where the index starts from 1. Example: command `cola get-city-population France Paris` will get environment variable `COLA_ARG_1=France` and `COLA_ARG_2=Paris`. An additional environment variable `COLA_NARGS` (available in 1.9+) is available as well to get the number of parsed arguments.
 
-> Even checkFlags is set to `true`, command launcher will still pass through the original arguments to the callee command as well, in addition, to the original arguments, parsed flags and arguments are passed to the callee as environment variables.
+> Even checkFlags is set to `true`, command launcher will still pass through the original arguments to the callee command as well; in addition to the original arguments, parsed flags and arguments are passed to the callee as environment variables.
 
-Another behavior change is that once `checkFlags` is enabled, the `-h` and `--help` flags are handled by command launcher. The original behavior is managed by the callee command itself.
+Another behavior change is that once `checkFlags` is enabled, the `-h` and `--help` flags are handled by Command Launcher. The original behavior is for these to be managed by the callee command itself.
 
 ### requestedResources
 
-Under the user consent, command launcher can pass several resources to the callee command, for example, the user credential collected and stored securely by the built-in `login` command. The `requestedResources` is used to request such resources. Command launcher will prompt user consent for the first time, and pass requested resources value to the callee command through environment variable. More detail see: [Manage resources](../resources)
+Under the user consent, Command Launcher can pass several resources to the callee command, for example, the user credentials collected and stored securely by the built-in `login` command. The `requestedResources` property is used to request such resources. Command Launcher will prompt user consent for the first time, and pass requested resources value to the callee command through environment variables. More detail see: [Manage resources](../resources)
 
-The following snippet requests to access the user name and password resources.
+The following snippet requests access the `USERNAME` and `PASSWORD` resources.
 
 ```json
 {
@@ -543,15 +549,15 @@ The following snippet requests to access the user name and password resources.
 
 ## System commands
 
-Besides the [system command](../system-package/#system-commands) defined in a [system package](../system-package). You can define package level system command as a lifecycle hook.
+Besides the [system command](../system-package/#system-commands) defined in a [system package](../system-package). You can define a package-level system command as a lifecycle hook.
 
 ### \_\_setup\_\_
 
-When a package is installed, sometimes it requires some setups to make it work properly. For example, a command written in javascript could require a `npm install` to install all its dependencies. You can define a system command `__setup__` in your package as a normal command, with type `system`, it will be called when the package is installed. (You can disable this behavior, by turning the configuration `enable_package_setup_hook` to `false`). You can also manually trigger it through the built-in command: `cola package setup`
+When a package is installed, sometimes it requires some setup to make it work properly. For example, a command written in javascript could require a `npm install` to install all of its dependencies. You can define a system command `__setup__` in your package as a normal command, with type `system`, it will be called when the package is installed. (You can disable this behavior, by turning the configuration `enable_package_setup_hook` to `false`). You can also manually trigger it through the built-in command: `cola package setup`
 
-> Make sure the setup hook is idempotent, when a new version is installed the setup hook will be called again.
+> Make sure the setup hook is _idempotent_, when a new version is installed the setup hook will be called again.
 
-**Example**
+**Example:**
 
 ```yaml
 pkgName: package-demo

--- a/gh-pages/content/en/docs/overview/resources.md
+++ b/gh-pages/content/en/docs/overview/resources.md
@@ -14,15 +14,15 @@ weight: 250
 toc: true
 ---
 
-## What is resources
+## What are Resources
 
-Resources are the information collected by command launcher. One good example is the user name and password from the built-in `login` command.
+Resources are the information collected by Command Launcher. One good example is the _username_ and _password_ from the built-in `login` command.
 
-Some of these information require user consent to access them, a command needs to explicitly request the access to these resources through the `requestedResources` property in the manifest.
+Some of these pieces of information require user consent to access them, a command needs to explicitly request the access to these resources through the `requestedResources` property in the manifest.
 
 Others are automatically passed to the command.
 
-Command Launcher passes resources to managed command through environment variables. The naming convention is: COLA_[RESOURCE_NAME]. If you compiled command launcher to a different name, command launcher will pass an additional environment variable `[APP_NAME]_[RESOURCE_NAME]` to the managed command as well.
+Command Launcher passes resources to managed commands through environment variables. The naming convention is: COLA_[RESOURCE_NAME]. If you compiled command launcher to a different name, command launcher will pass an additional environment variable `[APP_NAME]_[RESOURCE_NAME]` to the managed command as well.
 
 For example, the following snippet of manifest requests the resource `USERNAME` and `AUTH_TOKEN`.
 
@@ -48,11 +48,11 @@ Command 'create-pod' requests access to the following resources:
 authorize the access? [yN]
 ```
 
-The user consent will last for a specific period of time define in `user_consent_life` configuration.
+The user consent will last for a specific period of time define in the `user_consent_life` configuration entry.
 
 ## Access resources in your command
 
-Once user grant the access to the requested resources, command launcher will pass the resources to the command in runtime through environment variable with naming convention: `COLA_[RESOURCE_NAME]`. Here is an example of bash script:
+Once the user grants access to the requested resources, Command Launcher will pass the resources to the command at runtime through environment variables with the naming convention: `COLA_[RESOURCE_NAME]`. Here is an example of a bash script:
 
 ```bash
 #!/bin/bash

--- a/gh-pages/content/en/docs/overview/system-package.md
+++ b/gh-pages/content/en/docs/overview/system-package.md
@@ -14,13 +14,13 @@ weight: 800
 toc: true
 ---
 
-## What is a system package
+## What is a System Package
 
-System package is like other command launcher packages, with one `manifest.mf` file in it to describe the commands and contains binaries, scripts, and resources to execute these commands.
+A System Package is like any other Command Launcher package, with one `manifest.mf` file in it to describe the commands, and containing binaries, scripts, and resources to execute those commands.
 
-The difference is that a system package contains `system` commands, and it can be only installed from a central repository (not as a dropin package).
+The difference is that a System Package contains `system` commands, and it can only be installed from a central repository (not as a dropin package).
 
-You can customize your command launcher by providing a system package. In a system package, you can define system commands as functional hooks to extend command launcher's built-in functionalities, for example, login and metrics.
+You can customize your Command Launcher by providing a system package. In a system package, you can define system commands as functional hooks to extend Command Launcher's built-in functionalities, for example, `login` and `metrics`.
 
 ## Define system package
 
@@ -52,7 +52,7 @@ cmds:
 
 ## System commands
 
-To extend command launcher, you need to specify `system` type command in a system package.
+To extend Command Launcher built-in functionality, you need to specify some `system` type commands in a system package.
  The following table lists available system commands:
 
 | system command name | description                                     |
@@ -92,7 +92,7 @@ To use these credentials see [Manage resources](../resources)
 
 ### System command \_\_metrics\_\_
 
-At the end of each command launcher execution, the `__metrics__` system hook will be triggered. The following arguments will be passed to `__metrics__` system command in order:
+At the end of each Command Launcher execution, the `__metrics__` system hook will be triggered. The following arguments will be passed to the `__metrics__` system command in order:
 
 1. repository/registry name (see remote command)
 2. package name
@@ -110,4 +110,4 @@ Here is an example:
 __metrics__ default example cola-example hello 2 0 5000000 nil 1668363339
 ```
 
-> Note: the `__metrics__` hook will be called at the end of each command launcher call, please make sure it ends fast to reduce the footprint
+> Note: the `__metrics__` hook will be called at the end of **each Command Launcher call**, please make sure it ends fast to reduce the footprint.

--- a/gh-pages/content/en/docs/overview/variable.md
+++ b/gh-pages/content/en/docs/overview/variable.md
@@ -1,7 +1,7 @@
 ---
-title: "Variable in manifest"
-description: "Use variables in manifest.mf file"
-lead: "Use variables in manifest.mf file"
+title: "Variables in manifest"
+description: "Use of variables in the manifest.mf file"
+lead: "Use of variables in the manifest.mf file"
 date: 2022-10-02T21:36:35+02:00
 lastmod: 2022-10-02T21:36:35+02:00
 draft: false
@@ -14,33 +14,33 @@ weight: 999
 toc: true
 ---
 
-The two common use cases of integrating commands in command launcher are:
+The values of certain fields in the manifest file can be set using predefined variables. These variables are replaced with their actual values at runtime.
 
-1. Reference files that are located in the package itself
-2. Provide system/architecture-aware commands, for example, .sh script for linux, and .bat script for windows
+The two most common use cases of variables in a Command Launcher's manifest.mf file are:
 
-To cover these use cases, in certain fields of the manifest file, predefined variables can used in the field values.
+1. Referencing files that are located in the package directory itself
+2. Providing system/architecture-aware commands, for example, .sh script for linux, and .bat script for windows
 
 ## Available Variables
 
 | Variable Name   | Variable Description                                                   |
 |-----------------|------------------------------------------------------------------------|
 | PackageDir      | The absolute path of the package                                       |
-| Root            | Same as "PackageDir" variable                                          |
-| Cache           | Same as "PackageDir" variable                                          |
-| Os              | The OS, "windows", "linux", and "darwin"                               |
+| Root            | Same as the "PackageDir" variable                                      |
+| Cache           | Same as the "PackageDir" variable                                      |
+| Os              | The OS: "windows", "linux", or "darwin"                                |
 | Arch            | The system architecture: "arm64", "amd64"                              |
-| Binary          | The binary file name of the command launcher                           |
+| Binary          | The binary file name of the Command Launcher                           |
 | Extension       | The system-aware binary extension, "" for linux, ".exe" for windows    |
-| ScriptExtension | The system-aware scritp extension, ".sh" for linux, ".bat" for windows |
+| ScriptExtension | The system-aware script extension, ".sh" for linux, ".bat" for windows |
 
-## Fields that accepts variables
+## Fields that accept variables
 
-The command fields: `executable`, `args`, and `validArgsCmd`
+Variables can only be used in the command properties: `executable`, `args`, and `validArgsCmd`
 
 ## How to use these variables
 
-You can reference them in form of `{{.Variable}}`. For example:
+You can reference them in this format: `{{.Variable}}`. For example:
 
 ```json
 "cmds": [
@@ -52,11 +52,11 @@ You can reference them in form of `{{.Variable}}`. For example:
 ]
 ```
 
-The executable on linux will be a script called `script.sh` located in the bin folder of the package. On windows, the executable will be a script called `script.bat`.
+The executable on Linux will be a script called `script.sh` located in the `bin` folder of the package. On windows, the executable will be a script called `script.bat`.
 
 ## If Else
 
-One common scenario is to have different path or file name according to different OS. You can use condition (if-else) in the fields that accept variables. For example:
+One common scenario is to have a different path or file name, depending on what OS Command Launcher is running on. You can use a conditional structure (if-else) in the fields that accept variables. For example:
 
 ```json
 "cmds": [
@@ -68,7 +68,7 @@ One common scenario is to have different path or file name according to differen
 ]
 ```
 
-The executable on linux will be a script called `script.sh` located in the bin folder of the package. On windows, the executable will be a script called `script.ps1`.
+The executable on Linux will be a script called `script.sh` located in the `bin` folder of the package. On Windows, the executable will be a script called `script.ps1`.
 
 ## Advanced usage of variables
 


### PR DESCRIPTION
I've been thinking a lot about the docs, and while doing so, I've gone over them a number of times and done some minor editing. We could call this basic "linting" for the docs 👼 .

This is a conservative documentation review, focusing on these changes while striving to avoid any structural differences:

* General grammar and spelling review
* Capitalised Command Launcher in the docs
* Added missing punctuation
* Reordered some sections to make them easier to follow