### PR TITLE
Move to upload/download-artifact@v4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,15 +75,15 @@ jobs:
       run: cd gh-pages && npm install && npm run test
 
     - name: Upload CDT
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: ${{steps.vars.outputs.os}}-${{matrix.arch}}
+        name: ${{steps.vars.outputs.os}}-cdt-${{matrix.arch}}
         path: build/cdt_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}}
 
     - name: Upload COLA
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: ${{steps.vars.outputs.os}}-${{matrix.arch}}
+        name: ${{steps.vars.outputs.os}}-cola-${{matrix.arch}}
         path: build/cola_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}}
 
     - name: Rename binary name for release
@@ -105,29 +105,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download linux amd64 artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: linux-amd64
+          name: linux-cdt-amd64
           path: output/linux/amd64/
       - name: Download linux arm64 artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: linux-arm64
+          name: linux-cdt-arm64
           path: output/linux/arm64/
       - name: Download windows amd64 artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: windows-amd64
+          name: windows-cdt-amd64
           path: output/windows/amd64/
       - name: Download darwin amd64 artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: darwin-amd64
+          name: darwin-cdt-amd64
           path: output/darwin/amd64/
       - name: Download darwin-arm64 artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: darwin-arm64
+          name: darwin-cdt-arm64
           path: output/darwin/arm64/
 
       - name: Rename binary name
@@ -147,7 +147,7 @@ jobs:
           directory: output
 
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: all-in-one.zip
@@ -179,7 +179,7 @@ jobs:
         run: cat output/latest.yaml
 
       - name: Upload latest version index
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: latest.yaml
           path: output/latest.yaml


### PR DESCRIPTION
v3 images have been deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

They are unusable since Jan 30th 2025.

Migration: https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/

Artifact uploads already use proper matrix variables where needed.