### PR TITLE
Update workflows to use upload-artifact v4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,13 +75,13 @@ jobs:
       run: cd gh-pages && npm install && npm run test
 
     - name: Upload CDT
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{steps.vars.outputs.os}}-${{matrix.arch}}
         path: build/cdt_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}}
 
     - name: Upload COLA
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{steps.vars.outputs.os}}-${{matrix.arch}}
         path: build/cola_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}}
@@ -147,7 +147,7 @@ jobs:
           directory: output
 
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: all-in-one.zip
@@ -179,7 +179,7 @@ jobs:
         run: cat output/latest.yaml
 
       - name: Upload latest version index
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: latest.yaml
           path: output/latest.yaml


### PR DESCRIPTION
[v3 is deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) and unavailable since Jan 30th, 2025. This makes workflows fail unconditionally. None of the [migration changes](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) apply here, so it's only a matter of declaring the new version.