### PR TITLE
Fix package update message

### DIFF
--- a/internal/updater/cmd-updater.go
+++ b/internal/updater/cmd-updater.go
@@ -104,7 +104,7 @@ func (u *CmdUpdater) Update() error {
 			if remote.IsVersionSmaller(remoteVersion, localPkg.Version()) {
 				op = "downgrade"
 			}
-			console.Highlight("- %s command '%s' from version %s to version %s ...\n", op, pkgName, localPkg.Version(), remoteVersion)
+			console.Highlight("- %s package '%s' from version %s to version %s ...\n", op, pkgName, localPkg.Version(), remoteVersion)
 			pkg, err := remoteRepo.Package(pkgName, remoteVersion)
 			if err != nil {
 				errPool = append(errPool, err)
@@ -118,7 +118,7 @@ func (u *CmdUpdater) Update() error {
 			}
 			if err = repo.Update(pkg); err != nil {
 				errPool = append(errPool, err)
-				fmt.Printf("Cannot update the command %s: %v\n", pkgName, err)
+				fmt.Printf("Cannot update the package %s: %v\n", pkgName, err)
 			}
 		}
 	}

--- a/test/integration/test-remote.sh
+++ b/test/integration/test-remote.sh
@@ -48,7 +48,7 @@ fi
 
 echo "> test update command"
 RESULT=$($OUTPUT_DIR/cl update --package)
-echo "$RESULT" | grep "upgrade command 'command-launcher-demo' from version 1.0.0 to version 2.0.0"
+echo "$RESULT" | grep "upgrade package 'command-launcher-demo' from version 1.0.0 to version 2.0.0"
 if [ $? -eq 0 ]; then
   echo "OK"
 else


### PR DESCRIPTION
Today, the package upgrade message uses "command" instead of "package", which is misleading. 

This fix correct the misleading mesage.