### PR TITLE
Remote registry  local filesystem store

### DIFF
--- a/remote-registry/store/filestore.go
+++ b/remote-registry/store/filestore.go
@@ -1,0 +1,388 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	remote "github.com/criteo/command-launcher/internal/remote"
+	model "github.com/criteo/command-launcher/remote-registry/model"
+)
+
+// FileStore implements the storage interface with file system persistence
+type FileStore struct {
+	basePath string
+	mutex    sync.RWMutex
+	// Cache to avoid reading from disk on every operation
+	registriesCache map[string]*model.Registry
+}
+
+// NewFileStore creates a new file-based store
+func NewFileStore(storagePath string) (*FileStore, error) {
+	if err := os.MkdirAll(storagePath, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create storage directory: %w", err)
+	}
+
+	store := &FileStore{
+		basePath:        storagePath,
+		registriesCache: make(map[string]*model.Registry),
+	}
+
+	// Initialize cache by loading existing registries
+	if err := store.loadRegistriesFromDisk(); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+// loadRegistriesFromDisk reads all registry files into cache
+func (s *FileStore) loadRegistriesFromDisk() error {
+	entries, err := os.ReadDir(s.basePath)
+	if err != nil {
+		return fmt.Errorf("failed to read storage directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		registryName := entry.Name()[:len(entry.Name())-5] // Remove .json
+		registry, err := s.loadRegistryFromDisk(registryName)
+		if err != nil {
+			return err
+		}
+
+		s.registriesCache[registryName] = registry
+	}
+
+	return nil
+}
+
+// loadRegistryFromDisk loads a single registry from disk
+func (s *FileStore) loadRegistryFromDisk(name string) (*model.Registry, error) {
+	path := filepath.Join(s.basePath, fmt.Sprintf("%s.json", name))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, RegistryDoesNotExistError
+		}
+		return nil, fmt.Errorf("failed to read registry file: %w", err)
+	}
+
+	var registry model.Registry
+	if err := json.Unmarshal(data, &registry); err != nil {
+		return nil, fmt.Errorf("failed to parse registry file: %w", err)
+	}
+
+	return &registry, nil
+}
+
+// saveRegistryToDisk writes a registry to disk
+func (s *FileStore) saveRegistryToDisk(registry *model.Registry) error {
+	data, err := json.MarshalIndent(registry, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal registry: %w", err)
+	}
+
+	path := filepath.Join(s.basePath, fmt.Sprintf("%s.json", registry.Name))
+	return os.WriteFile(path, data, 0644)
+}
+
+// NewRegistry creates a new registry
+func (s *FileStore) NewRegistry(name string, registryInfo model.RegistryMetadata) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if _, exists := s.registriesCache[name]; exists {
+		return RegistryAlreadyExistsError
+	}
+	if name != registryInfo.Name {
+		return RegistryNameMismatchError
+	}
+
+	registry := &model.Registry{
+		RegistryMetadata: registryInfo,
+		Packages:         make(map[string]model.Package),
+	}
+
+	// Save to disk
+	if err := s.saveRegistryToDisk(registry); err != nil {
+		return err
+	}
+
+	// Update cache
+	s.registriesCache[name] = registry
+	return nil
+}
+
+// UpdateRegistry updates an existing registry
+func (s *FileStore) UpdateRegistry(name string, registryInfo model.RegistryMetadata) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	registry, exists := s.registriesCache[name]
+	if !exists {
+		return RegistryDoesNotExistError
+	}
+	if name != registryInfo.Name {
+		return RegistryNameMismatchError
+	}
+
+	// Update registry metadata
+	registry.Description = registryInfo.Description
+	registry.Admin = registryInfo.Admin
+	registry.CustomValues = registryInfo.CustomValues
+
+	// Save to disk
+	if err := s.saveRegistryToDisk(registry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteRegistry removes a registry
+func (s *FileStore) DeleteRegistry(name string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if _, exists := s.registriesCache[name]; !exists {
+		return RegistryDoesNotExistError
+	}
+
+	// Remove from disk
+	path := filepath.Join(s.basePath, fmt.Sprintf("%s.json", name))
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("failed to delete registry file: %w", err)
+	}
+
+	// Remove from cache
+	delete(s.registriesCache, name)
+	return nil
+}
+
+// AllRegistries returns all registries
+func (s *FileStore) AllRegistries() ([]model.Registry, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	registries := []model.Registry{}
+	for _, registry := range s.registriesCache {
+		registries = append(registries, *registry)
+	}
+
+	// Sort registries by name
+	sort.Slice(registries, func(i, j int) bool {
+		return registries[i].Name < registries[j].Name
+	})
+
+	return registries, nil
+}
+
+// NewPackage creates a new package in a registry
+func (s *FileStore) NewPackage(registryName string, packageName string, packageInfo model.PackageMetadata) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	registry, exists := s.registriesCache[registryName]
+	if !exists {
+		return RegistryDoesNotExistError
+	}
+	if _, exists := registry.Packages[packageName]; exists {
+		return PackageAlreadyExistsError
+	}
+	if packageName != packageInfo.Name {
+		return PackageNameMismatchError
+	}
+
+	// Add package
+	registry.Packages[packageName] = model.Package{
+		PackageMetadata: packageInfo,
+		Versions:        []remote.PackageInfo{},
+	}
+
+	// Save to disk
+	if err := s.saveRegistryToDisk(registry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdatePackage updates an existing package
+func (s *FileStore) UpdatePackage(registryName string, packageName string, packageInfo model.PackageMetadata) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	registry, exists := s.registriesCache[registryName]
+	if !exists {
+		return RegistryDoesNotExistError
+	}
+	pkg, exists := registry.Packages[packageName]
+	if !exists {
+		return PackageDoesNotExistError
+	}
+	if packageName != packageInfo.Name {
+		return PackageNameMismatchError
+	}
+
+	// Update package metadata
+	pkg.Description = packageInfo.Description
+	pkg.Admin = packageInfo.Admin
+	pkg.CustomValues = packageInfo.CustomValues
+	registry.Packages[packageName] = pkg
+
+	// Save to disk
+	if err := s.saveRegistryToDisk(registry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeletePackage removes a package from a registry
+func (s *FileStore) DeletePackage(registryName string, packageName string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	registry, exists := s.registriesCache[registryName]
+	if !exists {
+		return RegistryDoesNotExistError
+	}
+	if _, exists := registry.Packages[packageName]; !exists {
+		return PackageDoesNotExistError
+	}
+
+	// Delete package
+	delete(registry.Packages, packageName)
+
+	// Save to disk
+	if err := s.saveRegistryToDisk(registry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AllPackagesFromRegistry returns all packages in a registry
+func (s *FileStore) AllPackagesFromRegistry(registryName string) ([]model.Package, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	registry, exists := s.registriesCache[registryName]
+	if !exists {
+		return nil, RegistryDoesNotExistError
+	}
+
+	packages := []model.Package{}
+	for _, pkg := range registry.Packages {
+		packages = append(packages, pkg)
+	}
+
+	// Sort packages by name
+	sort.Slice(packages, func(i, j int) bool {
+		return packages[i].Name < packages[j].Name
+	})
+
+	return packages, nil
+}
+
+// NewPackageVersion adds a version to a package
+func (s *FileStore) NewPackageVersion(registryName string, packageName string, version string, packageInfo remote.PackageInfo) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	registry, exists := s.registriesCache[registryName]
+	if !exists {
+		return RegistryDoesNotExistError
+	}
+	pkg, exists := registry.Packages[packageName]
+	if !exists {
+		return PackageDoesNotExistError
+	}
+	if packageName != packageInfo.Name {
+		return PackageNameMismatchError
+	}
+
+	// Check if version already exists
+	for _, v := range pkg.Versions {
+		if v.Version == version {
+			return PackageVersionAlreadyExistsError
+		}
+	}
+
+	// Add version
+	pkg.Versions = append(pkg.Versions, packageInfo)
+	registry.Packages[packageName] = pkg
+
+	// Save to disk
+	if err := s.saveRegistryToDisk(registry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeletePackageVersion removes a version from a package
+func (s *FileStore) DeletePackageVersion(registryName string, packageName string, version string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	registry, exists := s.registriesCache[registryName]
+	if !exists {
+		return RegistryDoesNotExistError
+	}
+	pkg, exists := registry.Packages[packageName]
+	if !exists {
+		return PackageDoesNotExistError
+	}
+
+	// Find and remove version
+	newVersions := []remote.PackageInfo{}
+	exists = false
+	for _, v := range pkg.Versions {
+		if v.Version == version {
+			exists = true
+		}
+		if v.Version != version {
+			newVersions = append(newVersions, v)
+		}
+	}
+	if !exists {
+		return PackageVersionDoesNotExistError
+	}
+	pkg.Versions = newVersions
+	registry.Packages[packageName] = pkg
+
+	// Save to disk
+	if err := s.saveRegistryToDisk(registry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AllPackageVersionsFromRegistry returns all versions of a package
+func (s *FileStore) AllPackageVersionsFromRegistry(registryName string, packageName string) ([]remote.PackageInfo, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	registry, exists := s.registriesCache[registryName]
+	if !exists {
+		return nil, RegistryDoesNotExistError
+	}
+	pkg, exists := registry.Packages[packageName]
+	if !exists {
+		return nil, PackageDoesNotExistError
+	}
+
+	versions := make([]remote.PackageInfo, len(pkg.Versions))
+	copy(versions, pkg.Versions)
+
+	return versions, nil
+}

--- a/remote-registry/store/filestore_test.go
+++ b/remote-registry/store/filestore_test.go
@@ -1,0 +1,370 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	remote "github.com/criteo/command-launcher/internal/remote"
+	model "github.com/criteo/command-launcher/remote-registry/model"
+)
+
+func TestFileStore(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "filestore-test")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	t.Run("Initialize empty store", func(t *testing.T) {
+		store, err := NewFileStore(tempDir)
+		if err != nil {
+			t.Fatalf("Failed to create file store: %v", err)
+		}
+
+		registries, err := store.AllRegistries()
+		if err != nil {
+			t.Fatalf("Failed to list registries: %v", err)
+		}
+
+		if len(registries) != 0 {
+			t.Errorf("Expected empty store, got %d registries", len(registries))
+		}
+	})
+
+	t.Run("Registry operations", func(t *testing.T) {
+		// Create a new store for this test
+		storeDir := filepath.Join(tempDir, "registry-ops")
+		store, err := NewFileStore(storeDir)
+		if err != nil {
+			t.Fatalf("Failed to create file store: %v", err)
+		}
+
+		// Create registry
+		regMeta := model.RegistryMetadata{
+			Name:        "test-registry",
+			Description: "Test Registry",
+			Admin:       []string{"admin"},
+			CustomValues: map[string]string{
+				"key": "value",
+			},
+		}
+
+		err = store.NewRegistry("test-registry", regMeta)
+		if err != nil {
+			t.Fatalf("Failed to create registry: %v", err)
+		}
+
+		// Verify registry file exists
+		if _, err := os.Stat(filepath.Join(storeDir, "test-registry.json")); os.IsNotExist(err) {
+			t.Errorf("Registry file not created")
+		}
+
+		// List registries
+		registries, err := store.AllRegistries()
+		if err != nil {
+			t.Fatalf("Failed to list registries: %v", err)
+		}
+
+		if len(registries) != 1 {
+			t.Errorf("Expected 1 registry, got %d", len(registries))
+		}
+
+		if registries[0].Name != "test-registry" {
+			t.Errorf("Expected registry name 'test-registry', got '%s'", registries[0].Name)
+		}
+
+		// Update registry
+		regMeta.Description = "Updated Description"
+		err = store.UpdateRegistry("test-registry", regMeta)
+		if err != nil {
+			t.Fatalf("Failed to update registry: %v", err)
+		}
+
+		// Verify update
+		registries, _ = store.AllRegistries()
+		if registries[0].Description != "Updated Description" {
+			t.Errorf("Registry update failed, expected description 'Updated Description', got '%s'",
+				registries[0].Description)
+		}
+
+		// Delete registry
+		err = store.DeleteRegistry("test-registry")
+		if err != nil {
+			t.Fatalf("Failed to delete registry: %v", err)
+		}
+
+		// Verify registry is gone
+		registries, _ = store.AllRegistries()
+		if len(registries) != 0 {
+			t.Errorf("Registry not deleted, still have %d registries", len(registries))
+		}
+
+		// Verify file is gone
+		if _, err := os.Stat(filepath.Join(storeDir, "test-registry.json")); !os.IsNotExist(err) {
+			t.Errorf("Registry file not deleted")
+		}
+	})
+
+	t.Run("Package operations", func(t *testing.T) {
+		// Create a new store for this test
+		storeDir := filepath.Join(tempDir, "package-ops")
+		store, err := NewFileStore(storeDir)
+		if err != nil {
+			t.Fatalf("Failed to create file store: %v", err)
+		}
+
+		// Create a registry for testing
+		regMeta := model.RegistryMetadata{
+			Name:        "test-registry",
+			Description: "Test Registry",
+			Admin:       []string{"admin"},
+		}
+		store.NewRegistry("test-registry", regMeta)
+
+		// Create package
+		pkgMeta := model.PackageMetadata{
+			Name:        "test-package",
+			Description: "Test Package",
+			Admin:       []string{"admin"},
+			CustomValues: map[string]string{
+				"key": "value",
+			},
+		}
+
+		err = store.NewPackage("test-registry", "test-package", pkgMeta)
+		if err != nil {
+			t.Fatalf("Failed to create package: %v", err)
+		}
+
+		// List packages
+		packages, err := store.AllPackagesFromRegistry("test-registry")
+		if err != nil {
+			t.Fatalf("Failed to list packages: %v", err)
+		}
+
+		if len(packages) != 1 {
+			t.Errorf("Expected 1 package, got %d", len(packages))
+		}
+
+		if packages[0].Name != "test-package" {
+			t.Errorf("Expected package name 'test-package', got '%s'", packages[0].Name)
+		}
+
+		// Update package
+		pkgMeta.Description = "Updated Package"
+		err = store.UpdatePackage("test-registry", "test-package", pkgMeta)
+		if err != nil {
+			t.Fatalf("Failed to update package: %v", err)
+		}
+
+		// Verify update
+		packages, _ = store.AllPackagesFromRegistry("test-registry")
+		if packages[0].Description != "Updated Package" {
+			t.Errorf("Package update failed, expected description 'Updated Package', got '%s'",
+				packages[0].Description)
+		}
+
+		// Delete package
+		err = store.DeletePackage("test-registry", "test-package")
+		if err != nil {
+			t.Fatalf("Failed to delete package: %v", err)
+		}
+
+		// Verify package is gone
+		packages, _ = store.AllPackagesFromRegistry("test-registry")
+		if len(packages) != 0 {
+			t.Errorf("Package not deleted, still have %d packages", len(packages))
+		}
+	})
+
+	t.Run("Package version operations", func(t *testing.T) {
+		// Create a new store for this test
+		storeDir := filepath.Join(tempDir, "version-ops")
+		store, err := NewFileStore(storeDir)
+		if err != nil {
+			t.Fatalf("Failed to create file store: %v", err)
+		}
+
+		// Create a registry and package for testing
+		store.NewRegistry("test-registry", model.RegistryMetadata{Name: "test-registry"})
+		store.NewPackage("test-registry", "test-package", model.PackageMetadata{Name: "test-package"})
+
+		// Create package version
+		pkgInfo := remote.PackageInfo{
+			Name:    "test-package",
+			Version: "1.0.0",
+			Url:     "http://example.com/package-1.0.0.zip",
+		}
+
+		err = store.NewPackageVersion("test-registry", "test-package", "1.0.0", pkgInfo)
+		if err != nil {
+			t.Fatalf("Failed to create package version: %v", err)
+		}
+
+		// List versions
+		versions, err := store.AllPackageVersionsFromRegistry("test-registry", "test-package")
+		if err != nil {
+			t.Fatalf("Failed to list package versions: %v", err)
+		}
+
+		if len(versions) != 1 {
+			t.Errorf("Expected 1 version, got %d", len(versions))
+		}
+
+		if versions[0].Version != "1.0.0" {
+			t.Errorf("Expected version '1.0.0', got '%s'", versions[0].Version)
+		}
+
+		// Add another version
+		pkgInfo2 := remote.PackageInfo{
+			Name:    "test-package",
+			Version: "2.0.0",
+			Url:     "http://example.com/package-2.0.0.zip",
+		}
+		store.NewPackageVersion("test-registry", "test-package", "2.0.0", pkgInfo2)
+
+		// List versions again
+		versions, _ = store.AllPackageVersionsFromRegistry("test-registry", "test-package")
+		if len(versions) != 2 {
+			t.Errorf("Expected 2 versions, got %d", len(versions))
+		}
+
+		// Delete version
+		err = store.DeletePackageVersion("test-registry", "test-package", "1.0.0")
+		if err != nil {
+			t.Fatalf("Failed to delete package version: %v", err)
+		}
+
+		// Verify version is gone
+		versions, _ = store.AllPackageVersionsFromRegistry("test-registry", "test-package")
+		if len(versions) != 1 {
+			t.Errorf("Version not deleted, still have %d versions", len(versions))
+		}
+
+		if versions[0].Version != "2.0.0" {
+			t.Errorf("Wrong version deleted, expected '2.0.0', got '%s'", versions[0].Version)
+		}
+	})
+
+	t.Run("Error conditions", func(t *testing.T) {
+		// Create a new store for this test
+		storeDir := filepath.Join(tempDir, "error-ops")
+		store, err := NewFileStore(storeDir)
+		if err != nil {
+			t.Fatalf("Failed to create file store: %v", err)
+		}
+
+		// Try to update non-existent registry
+		err = store.UpdateRegistry("non-existent", model.RegistryMetadata{Name: "non-existent"})
+		if err != RegistryDoesNotExistError {
+			t.Errorf("Expected RegistryDoesNotExistError, got %v", err)
+		}
+
+		// Try to create registry with mismatched name
+		err = store.NewRegistry("registry1", model.RegistryMetadata{Name: "registry2"})
+		if err != RegistryNameMismatchError {
+			t.Errorf("Expected RegistryNameMismatchError, got %v", err)
+		}
+
+		// Create a valid registry for further tests
+		store.NewRegistry("test-registry", model.RegistryMetadata{Name: "test-registry"})
+
+		// Try to create duplicate registry
+		err = store.NewRegistry("test-registry", model.RegistryMetadata{Name: "test-registry"})
+		if err != RegistryAlreadyExistsError {
+			t.Errorf("Expected RegistryAlreadyExistsError, got %v", err)
+		}
+
+		// Try to create package in non-existent registry
+		err = store.NewPackage("non-existent", "test-package", model.PackageMetadata{Name: "test-package"})
+		if err != RegistryDoesNotExistError {
+			t.Errorf("Expected RegistryDoesNotExistError, got %v", err)
+		}
+
+		// Create a valid package for further tests
+		store.NewPackage("test-registry", "test-package", model.PackageMetadata{Name: "test-package"})
+
+		// Try to create duplicate package
+		err = store.NewPackage("test-registry", "test-package", model.PackageMetadata{Name: "test-package"})
+		if err != PackageAlreadyExistsError {
+			t.Errorf("Expected PackageAlreadyExistsError, got %v", err)
+		}
+
+		// Try to create package with mismatched name
+		err = store.NewPackage("test-registry", "package1", model.PackageMetadata{Name: "package2"})
+		if err != PackageNameMismatchError {
+			t.Errorf("Expected PackageNameMismatchError, got %v", err)
+		}
+	})
+
+	t.Run("Persistence between store instances", func(t *testing.T) {
+		// Create a dedicated directory for this test
+		storeDir := filepath.Join(tempDir, "persistence")
+
+		// Create first store instance and add data
+		store1, err := NewFileStore(storeDir)
+		if err != nil {
+			t.Fatalf("Failed to create first file store: %v", err)
+		}
+
+		// Create registry
+		regMeta := model.RegistryMetadata{
+			Name:        "persistent-registry",
+			Description: "This should persist between store instances",
+		}
+		store1.NewRegistry("persistent-registry", regMeta)
+
+		// Create package
+		pkgMeta := model.PackageMetadata{
+			Name:        "persistent-package",
+			Description: "This should persist between store instances",
+		}
+		store1.NewPackage("persistent-registry", "persistent-package", pkgMeta)
+
+		// Create version
+		pkgInfo := remote.PackageInfo{
+			Name:    "persistent-package",
+			Version: "1.0.0",
+			Url:     "http://example.com/package.zip",
+		}
+		store1.NewPackageVersion("persistent-registry", "persistent-package", "1.0.0", pkgInfo)
+
+		// Create a second store instance pointing to same directory
+		store2, err := NewFileStore(storeDir)
+		if err != nil {
+			t.Fatalf("Failed to create second file store: %v", err)
+		}
+
+		// Verify registry exists in second instance
+		registries, err := store2.AllRegistries()
+		if err != nil {
+			t.Fatalf("Failed to list registries in second store: %v", err)
+		}
+
+		if len(registries) != 1 || registries[0].Name != "persistent-registry" {
+			t.Errorf("Registry not persisted between store instances")
+		}
+
+		// Verify package exists
+		packages, err := store2.AllPackagesFromRegistry("persistent-registry")
+		if err != nil {
+			t.Fatalf("Failed to list packages in second store: %v", err)
+		}
+
+		if len(packages) != 1 || packages[0].Name != "persistent-package" {
+			t.Errorf("Package not persisted between store instances")
+		}
+
+		// Verify version exists
+		versions, err := store2.AllPackageVersionsFromRegistry("persistent-registry", "persistent-package")
+		if err != nil {
+			t.Fatalf("Failed to list versions in second store: %v", err)
+		}
+
+		if len(versions) != 1 || versions[0].Version != "1.0.0" {
+			t.Errorf("Package version not persisted between store instances")
+		}
+	})
+}


### PR DESCRIPTION
This is a new store managing registries metadata on the filesystem directly.

### Architecture
The whole store is represented with a folder.
The folder may contain several json files, each one defines a specific registry.

The store directory path is passed as a parameter, and if absent, it will default to the current working directory + `/registries`


### Example

```
$ ./cdt-registry --store filesystem --store-path $(mktemp -d)
2025/05/07 17:18:02 Using filesystem store at: /var/folders/cv/h0129pvn3gb2qkn77r_gk_pw0000gn/T/tmp.hSiZOmpQZM
2025/05/07 17:18:02 Filesystem store created at /var/folders/cv/h0129pvn3gb2qkn77r_gk_pw0000gn/T/tmp.hSiZOmpQZM
2025/05/07 17:18:02 Store initialized with example data, number of registries: 2
2025/05/07 17:18:02 Starting server on :8080

^C
$ ls /var/folders/cv/h0129pvn3gb2qkn77r_gk_pw0000gn/T/tmp.hSiZOmpQZM
test-registry-2.json test-registry.json
```
