### PR TITLE
Self-updater to only offer updates only to newer versions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -176,6 +176,7 @@ func initSelfUpdater() {
 		User:              rootCtxt.user,
 		CurrentVersion:    rootCtxt.appCtx.AppVersion(),
 		Timeout:           viper.GetDuration(config.SELF_UPDATE_TIMEOUT_KEY),
+		Policy:            config.SelfUpdatePolicy(viper.GetString(config.SELF_UPDATE_POLICY_KEY)),
 	}
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -53,6 +53,7 @@ Check the update of %s and its commands.
 					User:              u,
 					CurrentVersion:    appCtx.AppVersion(),
 					Timeout:           updateFlags.Timeout,
+					Policy:            config.SelfUpdatePolicy(viper.GetString(config.SELF_UPDATE_POLICY_KEY)),
 				}
 				selfUpdater.CheckUpdateAsync()
 				err := selfUpdater.Update()

--- a/examples/remote-config/remote_config_with_policy.json
+++ b/examples/remote-config/remote_config_with_policy.json
@@ -1,0 +1,5 @@
+{
+  "command_repository_base_url": "https://raw.githubusercontent.com/criteo/command-launcher/main/test/remote-repo",
+  "ci_enabled": true,
+  "self_update_policy": "only_newer_version"
+}

--- a/gh-pages/content/en/docs/overview/config.md
+++ b/gh-pages/content/en/docs/overview/config.md
@@ -36,6 +36,7 @@ toc: true
 | self_update_enabled              | bool     | whether auto update command launcher itself                                                                                   |
 | self_update_latest_version_url   | string   | url to get the latest command launcher version information                                                                    |
 | self_update_timeout              | duration | timeout duration for self update                                                                                              |
+| self_update_policy               | string   | self-update version comparison policy: `exact_match` or `only_newer_version` (default: `exact_match`)      |
 | usage_metrics_enabled            | bool     | whether enable metrics                                                                                                        |
 | user_consent_life                | duration | the life of user consent                                                                                                      |
 | system_package                   | string   | the system package name                                                                                                       |
@@ -70,6 +71,16 @@ Each extra remote must have a unique name, it is used to identify the command as
 | repository_dir  | string | the absolute path of the local repository folder to keep the downloaded local packages                                                                                     |
 
 > You don't need to manage these extra remote configurations by yourself. Use the built-in `remote` command instead.
+
+### Self-update policies
+
+The `self_update_policy` configuration controls how the self-updater determines when to offer updates:
+
+- **`exact_match`**: Offers updates whenever the remote version differs from the current version (legacy behavior). This can result in offering updates to older versions, which may be useful in specific rollback scenarios.
+
+- **`only_newer_version`**: Only offers updates when the remote version is newer than the current version.
+
+> **Note**: The default policy is `exact_match` to maintain legacy behavior. Enterprise environments can override this via remote configuration to enforce their preferred update strategy.
 
 ## Change configuration
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -82,6 +82,7 @@ func setDefaultConfig() {
 	viper.SetDefault(SELF_UPDATE_TIMEOUT_KEY, 2*time.Second) // In seconds
 	viper.SetDefault(SELF_UPDATE_LATEST_VERSION_URL_KEY, "")
 	viper.SetDefault(SELF_UPDATE_BASE_URL_KEY, "")
+	viper.SetDefault(SELF_UPDATE_POLICY_KEY, string(SelfUpdatePolicyExactMatch))
 
 	viper.SetDefault(COMMAND_UPDATE_ENABLED_KEY, false)
 	viper.SetDefault(COMMAND_REPOSITORY_BASE_URL_KEY, "")
@@ -146,10 +147,7 @@ func findLocalConfig(startPath string, configFileName string) (string, bool) {
 
 func hasConfigFile(configRootPath string, configFileName string) bool {
 	_, err := os.Stat(filepath.Join(configRootPath, configFileName))
-	if err == nil {
-		return true
-	}
-	return false
+	return err == nil
 }
 
 func loadRemoteConfig(appCtx context.LauncherContext) bool {

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetSelfUpdatePolicyConfig(t *testing.T) {
+	testCases := []struct {
+		value         string
+		expectedError bool
+		description   string
+	}{
+		{
+			value:         "exact_match",
+			expectedError: false,
+			description:   "Valid exact_match policy should succeed",
+		},
+		{
+			value:         "only_newer_version",
+			expectedError: false,
+			description:   "Valid only_newer_version policy should succeed",
+		},
+		{
+			value:         "invalid_policy",
+			expectedError: true,
+			description:   "Invalid policy should fail with error",
+		},
+		{
+			value:         "",
+			expectedError: true,
+			description:   "Empty policy should fail with error",
+		},
+		{
+			value:         "EXACT_MATCH",
+			expectedError: true,
+			description:   "Case sensitive - uppercase should fail",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := setSelfUpdatePolicyConfig(tc.value)
+			if tc.expectedError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid value for self-update policy")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/updater/self-updater.go
+++ b/internal/updater/self-updater.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/criteo/command-launcher/internal/console"
 	"github.com/criteo/command-launcher/internal/helper"
+	"github.com/criteo/command-launcher/internal/remote"
 	"github.com/criteo/command-launcher/internal/user"
 	"github.com/inconshreveable/go-update"
 	log "github.com/sirupsen/logrus"
@@ -102,8 +103,10 @@ func (u *SelfUpdater) checkSelfUpdate() <-chan bool {
 			return
 		}
 
-		ch <- u.latestVersion.Version != u.CurrentVersion &&
+		// Only offer update if remote version is newer than current version
+		shouldUpdate := remote.IsVersionSmaller(u.CurrentVersion, u.latestVersion.Version) &&
 			u.User.InPartition(u.latestVersion.StartPartition, u.latestVersion.EndPartition)
+		ch <- shouldUpdate
 	}()
 	return ch
 }

--- a/internal/updater/self-updater_test.go
+++ b/internal/updater/self-updater_test.go
@@ -1,0 +1,133 @@
+package updater
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/criteo/command-launcher/internal/user"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelfUpdaterCheckUpdate(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "self-updater-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	testCases := []struct {
+		currentVersion string
+		remoteVersion  string
+		shouldUpdate   bool
+		description    string
+	}{
+		{
+			currentVersion: "1.13.0-0",
+			remoteVersion:  "1.14.0-7",
+			shouldUpdate:   true,
+			description:    "Remote version is newer, should offer update",
+		},
+		{
+			currentVersion: "1.14.0-7",
+			remoteVersion:  "1.13.0-0",
+			shouldUpdate:   false,
+			description:    "Remote version is older, should NOT offer update",
+		},
+		{
+			currentVersion: "1.14.0-7",
+			remoteVersion:  "1.14.0-7",
+			shouldUpdate:   false,
+			description:    "Same version, should NOT offer update",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			// Create a test version file
+			versionFile := filepath.Join(tempDir, "version.yaml")
+			versionContent := fmt.Sprintf(`
+version: %s
+releaseNotes: "Test release notes"
+startPartition: 0
+endPartition: 255
+`, tc.remoteVersion)
+
+			err := os.WriteFile(versionFile, []byte(versionContent), 0644)
+			assert.NoError(t, err)
+
+			// Create a mock user
+			mockUser := user.User{
+				UID:                    "test-user",
+				Partition:              5, // Use a partition within the range 0-255
+				InternalCmdEnabled:     false,
+				ExperimentalCmdEnabled: false,
+			}
+
+			// Create SelfUpdater instance
+			updater := &SelfUpdater{
+				BinaryName:       "test-binary",
+				LatestVersionUrl: "file://" + versionFile,
+				CurrentVersion:   tc.currentVersion,
+				User:             mockUser,
+				Timeout:          5 * time.Second,
+			}
+
+			// Test the checkSelfUpdate functionality
+			updateChan := updater.checkSelfUpdate()
+
+			// Wait for the result
+			select {
+			case shouldUpdate := <-updateChan:
+				assert.Equal(t, tc.shouldUpdate, shouldUpdate,
+					"Current: %s, Remote: %s", tc.currentVersion, tc.remoteVersion)
+			case <-time.After(6 * time.Second):
+				t.Fatal("Timeout waiting for update check result")
+			}
+		})
+	}
+}
+
+func TestSelfUpdaterCheckUpdateWithPartitionFiltering(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "self-updater-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a test version file with partition restrictions
+	versionFile := filepath.Join(tempDir, "version.yaml")
+	versionContent := `
+version: 1.14.0-7
+releaseNotes: "Test release notes"
+startPartition: 10
+endPartition: 20
+`
+
+	err = os.WriteFile(versionFile, []byte(versionContent), 0644)
+	assert.NoError(t, err)
+
+	// Test with user outside the partition range
+	mockUserOutside := user.User{
+		UID:                    "test-user-outside",
+		Partition:              25, // Use a partition outside the range 10-20
+		InternalCmdEnabled:     false,
+		ExperimentalCmdEnabled: false,
+	}
+
+	updater := &SelfUpdater{
+		BinaryName:       "test-binary",
+		LatestVersionUrl: "file://" + versionFile,
+		CurrentVersion:   "1.13.0-0",
+		User:             mockUserOutside,
+		Timeout:          5 * time.Second,
+	}
+
+	updateChan := updater.checkSelfUpdate()
+
+	select {
+	case shouldUpdate := <-updateChan:
+		assert.False(t, shouldUpdate, "User outside partition range should not get update")
+	case <-time.After(6 * time.Second):
+		t.Fatal("Timeout waiting for update check result")
+	}
+}

--- a/internal/updater/self-updater_test.go
+++ b/internal/updater/self-updater_test.go
@@ -1,92 +1,15 @@
 package updater
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/criteo/command-launcher/internal/config"
 	"github.com/criteo/command-launcher/internal/user"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestSelfUpdaterCheckUpdate(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "self-updater-test")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tempDir)
-
-	testCases := []struct {
-		currentVersion string
-		remoteVersion  string
-		shouldUpdate   bool
-		description    string
-	}{
-		{
-			currentVersion: "1.13.0-0",
-			remoteVersion:  "1.14.0-7",
-			shouldUpdate:   true,
-			description:    "Remote version is newer, should offer update",
-		},
-		{
-			currentVersion: "1.14.0-7",
-			remoteVersion:  "1.13.0-0",
-			shouldUpdate:   false,
-			description:    "Remote version is older, should NOT offer update",
-		},
-		{
-			currentVersion: "1.14.0-7",
-			remoteVersion:  "1.14.0-7",
-			shouldUpdate:   false,
-			description:    "Same version, should NOT offer update",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			// Create a test version file
-			versionFile := filepath.Join(tempDir, "version.yaml")
-			versionContent := fmt.Sprintf(`
-version: %s
-releaseNotes: "Test release notes"
-startPartition: 0
-endPartition: 255
-`, tc.remoteVersion)
-
-			err := os.WriteFile(versionFile, []byte(versionContent), 0644)
-			assert.NoError(t, err)
-
-			// Create a mock user
-			mockUser := user.User{
-				UID:                    "test-user",
-				Partition:              5, // Use a partition within the range 0-255
-				InternalCmdEnabled:     false,
-				ExperimentalCmdEnabled: false,
-			}
-
-			// Create SelfUpdater instance
-			updater := &SelfUpdater{
-				BinaryName:       "test-binary",
-				LatestVersionUrl: "file://" + versionFile,
-				CurrentVersion:   tc.currentVersion,
-				User:             mockUser,
-				Timeout:          5 * time.Second,
-			}
-
-			// Test the checkSelfUpdate functionality
-			updateChan := updater.checkSelfUpdate()
-
-			// Wait for the result
-			select {
-			case shouldUpdate := <-updateChan:
-				assert.Equal(t, tc.shouldUpdate, shouldUpdate,
-					"Current: %s, Remote: %s", tc.currentVersion, tc.remoteVersion)
-			case <-time.After(6 * time.Second):
-				t.Fatal("Timeout waiting for update check result")
-			}
-		})
-	}
-}
 
 func TestSelfUpdaterCheckUpdateWithPartitionFiltering(t *testing.T) {
 	// Create a temporary directory for test files
@@ -120,6 +43,7 @@ endPartition: 20
 		CurrentVersion:   "1.13.0-0",
 		User:             mockUserOutside,
 		Timeout:          5 * time.Second,
+		Policy:           config.SelfUpdatePolicyOnlyNewer,
 	}
 
 	updateChan := updater.checkSelfUpdate()
@@ -129,5 +53,103 @@ endPartition: 20
 		assert.False(t, shouldUpdate, "User outside partition range should not get update")
 	case <-time.After(6 * time.Second):
 		t.Fatal("Timeout waiting for update check result")
+	}
+}
+
+func TestSelfUpdaterCheckUpdateWithDifferentPolicies(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "self-updater-policy-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a test version file
+	versionFile := filepath.Join(tempDir, "version.yaml")
+	versionContent := `
+version: 1.14.0-7
+releaseNotes: "Test release notes"
+startPartition: 0
+endPartition: 255
+`
+	err = os.WriteFile(versionFile, []byte(versionContent), 0644)
+	assert.NoError(t, err)
+
+	// Create a mock user
+	mockUser := user.User{
+		UID:                    "test-user",
+		Partition:              5,
+		InternalCmdEnabled:     false,
+		ExperimentalCmdEnabled: false,
+	}
+
+	testCases := []struct {
+		currentVersion string
+		policy         config.SelfUpdatePolicy
+		shouldUpdate   bool
+		description    string
+	}{
+		{
+			currentVersion: "1.13.0-0",
+			policy:         config.SelfUpdatePolicyExactMatch,
+			shouldUpdate:   true,
+			description:    "Exact match policy with different version should offer update",
+		},
+		{
+			currentVersion: "1.14.0-7",
+			policy:         config.SelfUpdatePolicyExactMatch,
+			shouldUpdate:   false,
+			description:    "Exact match policy with same version should NOT offer update",
+		},
+		{
+			currentVersion: "1.15.0-0",
+			policy:         config.SelfUpdatePolicyExactMatch,
+			shouldUpdate:   true,
+			description:    "Exact match policy with newer local version should offer update (rollback)",
+		},
+		{
+			currentVersion: "1.13.0-0",
+			policy:         config.SelfUpdatePolicyOnlyNewer,
+			shouldUpdate:   true,
+			description:    "Only newer policy with older local version should offer update",
+		},
+		{
+			currentVersion: "1.14.0-7",
+			policy:         config.SelfUpdatePolicyOnlyNewer,
+			shouldUpdate:   false,
+			description:    "Only newer policy with same version should NOT offer update",
+		},
+		{
+			currentVersion: "1.15.0-0",
+			policy:         config.SelfUpdatePolicyOnlyNewer,
+			shouldUpdate:   false,
+			description:    "Only newer policy with newer local version should NOT offer update",
+		},
+		{
+			currentVersion: "1.15.0-0",
+			policy:         "", // Test empty/invalid policy - should default to exact_match
+			shouldUpdate:   true,
+			description:    "Empty policy should default to exact_match and offer update (rollback)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			updater := &SelfUpdater{
+				BinaryName:       "test-binary",
+				LatestVersionUrl: "file://" + versionFile,
+				CurrentVersion:   tc.currentVersion,
+				User:             mockUser,
+				Timeout:          5 * time.Second,
+				Policy:           tc.policy,
+			}
+
+			updateChan := updater.checkSelfUpdate()
+
+			select {
+			case shouldUpdate := <-updateChan:
+				assert.Equal(t, tc.shouldUpdate, shouldUpdate,
+					"Current: %s, Remote: 1.14.0-7, Policy: %s", tc.currentVersion, tc.policy)
+			case <-time.After(6 * time.Second):
+				t.Fatal("Timeout waiting for update check result")
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR switches the version comparison of the self-updater from a simple inequality check to a full version comparison.

Fixes #158 