### PR TITLE
Add precheck field to check urls access before running command

### DIFF
--- a/cmd/prechecks/precheck_urls.go
+++ b/cmd/prechecks/precheck_urls.go
@@ -1,0 +1,59 @@
+package prechecks
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/criteo/command-launcher/internal/helper"
+)
+
+// PrecheckURLsAccess checks accessibility of the provided URLs using helper functions.
+// It returns nil when all URLs are accessible (HTTP status 2xx or 3xx).
+// If any URL is inaccessible an error is returned that lists the failing URLs.
+func PrecheckURLsAccess(urls []string) error {
+	if len(urls) == 0 {
+		return nil
+	}
+
+	var (
+		mu     sync.Mutex
+		failed []string
+		wg     sync.WaitGroup
+	)
+
+	for _, raw := range urls {
+		u := strings.TrimSpace(raw)
+		if u == "" {
+			continue
+		}
+		wg.Add(1)
+
+		go func(u string) {
+			defer wg.Done()
+
+			// Try HttpEtag first (lightweight HEAD request)
+			// which leverages URL resolution and TLS configuration from helper
+			statusCode, _, err := helper.HttpEtag(u)
+			if err == nil && helper.Is2xx(statusCode) {
+				// URL is accessible
+				return
+			}
+
+			// Fallback to HttpGet if HttpEtag fails or returns non-2xx
+			statusCode, _, err = helper.HttpGet(u)
+			if err != nil || !helper.Is2xx(statusCode) {
+				mu.Lock()
+				failed = append(failed, u)
+				mu.Unlock()
+			}
+		}(u)
+	}
+
+	wg.Wait()
+
+	if len(failed) == 0 {
+		return nil
+	}
+	return fmt.Errorf("inaccessible urls: %s", strings.Join(failed, ", "))
+}

--- a/cmd/prechecks/precheck_urls_test.go
+++ b/cmd/prechecks/precheck_urls_test.go
@@ -1,0 +1,76 @@
+package prechecks
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPrecheckURLsAccess(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok":
+			// HEAD and GET -> 200
+			w.WriteHeader(200)
+		case "/etagfail":
+			// HEAD -> 500, GET -> 200
+			if r.Method == http.MethodHead {
+				w.WriteHeader(500)
+				return
+			}
+			w.WriteHeader(200)
+		case "/bad":
+			// HEAD and GET -> 500
+			w.WriteHeader(500)
+		case "/redirect":
+			// HEAD and GET -> 301 redirect
+			w.Header().Set("Location", "/ok")
+			w.WriteHeader(301)
+		default:
+			w.WriteHeader(404)
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	t.Run("empty slice", func(t *testing.T) {
+		if err := PrecheckURLsAccess([]string{}); err != nil {
+			t.Fatalf("expected nil error for empty slice, got: %v", err)
+		}
+	})
+
+	t.Run("accessible via HEAD", func(t *testing.T) {
+		urls := []string{server.URL + "/ok"}
+		if err := PrecheckURLsAccess(urls); err != nil {
+			t.Fatalf("expected nil error for accessible url, got: %v", err)
+		}
+	})
+
+	t.Run("fallback to GET", func(t *testing.T) {
+		urls := []string{server.URL + "/etagfail"}
+		if err := PrecheckURLsAccess(urls); err != nil {
+			t.Fatalf("expected nil error when GET succeeds after HEAD fails, got: %v", err)
+		}
+	})
+
+	t.Run("redirect considered accessible", func(t *testing.T) {
+		urls := []string{server.URL + "/redirect"}
+		if err := PrecheckURLsAccess(urls); err != nil {
+			t.Fatalf("expected nil error for redirect (3xx) response, got: %v", err)
+		}
+	})
+
+	t.Run("inaccessible url reported", func(t *testing.T) {
+		bad := server.URL + "/bad"
+		urls := []string{server.URL + "/ok", bad, "   ", ""}
+		err := PrecheckURLsAccess(urls)
+		if err == nil {
+			t.Fatalf("expected error for inaccessible url, got nil")
+		}
+		if !strings.Contains(err.Error(), bad) {
+			t.Fatalf("error message does not contain failing url; got: %v", err)
+		}
+	})
+}

--- a/gh-pages/content/en/docs/overview/manifest.md
+++ b/gh-pages/content/en/docs/overview/manifest.md
@@ -72,6 +72,7 @@ These are the properties available to define each command:
 | groupFlags         | no                 | group of grouped flags, which must be presented together (available in 1.9+)                          |
 | checkFlags         | no                 | whether to check the flags defined in manifest before calling the command. Default: false             |
 | requestedResources | no                 | the resources that the command requested, e.g., `USERNAME`, `PASSWORD`                                |
+| precheckURLs       | no                 | pre-check URLs that must return OK before running the plugin                                          |
 
 ## Command properties
 
@@ -542,6 +543,30 @@ The following snippet requests access the `USERNAME` and `PASSWORD` resources.
       "executable": "get-city-population",
       "args": [],
       "requestedResources": [ "USERNAME", "PASSWORD" ]
+    }
+  ]
+}
+```
+
+### precheckURLs
+
+A list of external endpoints to probe before running the plugin. Each URL must return a successful HTTP response (for example, 200 OK). If any probe fails or times out, the plugin will not start and will report which endpoint(s) caused the failure. Use this to declare services the plugin depends on being available prior to execution.
+
+Example:
+
+```json
+{
+  "cmds": [
+    {
+      "name": "population",
+      "type": "executable",
+      "group": "city",
+      "executable": "get-city-population",
+      "args": [],
+      "precheckURLs": [
+        "https://api.example.com/health",
+        "http://internal-service.local:8080/ready"
+      ]
     }
   ]
 }

--- a/gh-pages/content/en/docs/overview/variable.md
+++ b/gh-pages/content/en/docs/overview/variable.md
@@ -47,7 +47,7 @@ You can reference them in this format: `{{.Variable}}`. For example:
   {
     "name": "variable-demo",
     "type": "executable",
-    "executable": "{{.PackageDir}}/bin/script{{.ScripteExtension}}",
+    "executable": "{{.PackageDir}}/bin/script{{.ScriptExtension}}",
   }
 ]
 ```

--- a/internal/command/api.go
+++ b/internal/command/api.go
@@ -47,6 +47,8 @@ type CommandManifest interface {
 	FlagValuesCmd() []string
 
 	CheckFlags() bool
+
+	PrecheckURLs() []string
 }
 
 type Command interface {

--- a/internal/command/default-command.go
+++ b/internal/command/default-command.go
@@ -74,6 +74,7 @@ type DefaultCommand struct {
 	CmdFlagValuesCmd      []string       `json:"flagValuesCmd" yaml:"flagValuesCmd"` // the command to call flag values for autocompletion
 	CmdCheckFlags         bool           `json:"checkFlags" yaml:"checkFlags"`       // whether parse the flags and check them before execution
 	CmdRequestedResources []string       `json:"requestedResources" yaml:"requestedResources"`
+	CmdPrecheckURLs       []string       `json:"precheckURLs" yaml:"precheckURLs"` // Pre-check URLs that must return OK before running the plugin
 
 	PkgDir string `json:"pkgDir"`
 }
@@ -107,6 +108,7 @@ func NewDefaultCommandFromCopy(cmd Command, pkgDir string) *DefaultCommand {
 		CmdFlagValuesCmd:      cmd.FlagValuesCmd(),
 		CmdCheckFlags:         cmd.CheckFlags(),
 		CmdRequestedResources: cmd.RequestedResources(),
+		CmdPrecheckURLs:       cmd.PrecheckURLs(),
 		PkgDir:                pkgDir,
 	}
 }
@@ -360,6 +362,13 @@ func (cmd *DefaultCommand) FlagValuesCmd() []string {
 
 func (cmd *DefaultCommand) CheckFlags() bool {
 	return cmd.CmdCheckFlags
+}
+
+func (cmd *DefaultCommand) PrecheckURLs() []string {
+	if cmd.CmdPrecheckURLs == nil {
+		return []string{}
+	}
+	return cmd.CmdPrecheckURLs
 }
 
 func (cmd *DefaultCommand) PackageDir() string {

--- a/internal/command/default-command_test.go
+++ b/internal/command/default-command_test.go
@@ -33,6 +33,7 @@ func getDefaultCommand() DefaultCommand {
 		CmdFlagValuesCmd:      nil,
 		CmdCheckFlags:         true,
 		CmdRequestedResources: nil,
+		CmdPrecheckURLs:       nil,
 		PkgDir:                "/tmp/test/root",
 	}
 }
@@ -40,6 +41,7 @@ func getDefaultCommand() DefaultCommand {
 func TestRequestResources(t *testing.T) {
 	cmd := getDefaultCommand()
 	assert.NotNil(t, cmd.RequestedResources())
+	assert.NotNil(t, cmd.PrecheckURLs())
 	assert.Equal(t, 0, len(cmd.RequestedResources()))
 }
 

--- a/internal/frontend/default-frontend.go
+++ b/internal/frontend/default-frontend.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/criteo/command-launcher/cmd/consent"
+	"github.com/criteo/command-launcher/cmd/prechecks"
 	"github.com/criteo/command-launcher/internal/backend"
 	"github.com/criteo/command-launcher/internal/command"
 	"github.com/criteo/command-launcher/internal/config"
@@ -87,6 +88,7 @@ func (self *defaultFrontend) addGroupCommands() {
 		))
 		requiredFlags := v.RequiredFlags()
 		requestedResources := v.RequestedResources()
+		CheckURLs := v.PrecheckURLs()
 		flags := v.Flags()
 		exclusiveFlags := v.ExclusiveFlags()
 		groupFlags := v.GroupFlags()
@@ -97,6 +99,12 @@ func (self *defaultFrontend) addGroupCommands() {
 			Short:              v.ShortDescription(),
 			Long:               v.LongDescription(),
 			Run: func(cmd *cobra.Command, args []string) {
+				err := prechecks.PrecheckURLsAccess(CheckURLs)
+				if err != nil {
+					log.Errorf("pre-check failed: %v", err)
+					RootExitCode = 1
+					return
+				}
 				consents, err := consent.GetConsents(group, name, requestedResources, viper.GetBool(config.ENABLE_USER_CONSENT_KEY))
 				if err != nil {
 					log.Warnf("failed to get user consent: %v", err)
@@ -140,6 +148,7 @@ func (self *defaultFrontend) addExecutableCommands() {
 		validArgsCmd := v.ValidArgsCmd()
 		checkFlags := v.CheckFlags()
 		requestedResources := v.RequestedResources()
+		CheckURLs := v.PrecheckURLs()
 		flags := v.Flags()
 		exclusiveFlags := v.ExclusiveFlags()
 		groupFlags := v.GroupFlags()
@@ -150,6 +159,12 @@ func (self *defaultFrontend) addExecutableCommands() {
 			Short:              v.ShortDescription(),
 			Long:               v.LongDescription(),
 			Run: func(c *cobra.Command, args []string) {
+				err := prechecks.PrecheckURLsAccess(CheckURLs)
+				if err != nil {
+					log.Errorf("pre-check failed: %v", err)
+					RootExitCode = 1
+					return
+				}
 				consents, err := consent.GetConsents(group, name, requestedResources, viper.GetBool(config.ENABLE_USER_CONSENT_KEY))
 				if err != nil {
 					log.Warnf("failed to get user consent: %v", err)

--- a/internal/pkg/default-package.go
+++ b/internal/pkg/default-package.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/criteo/command-launcher/cmd/prechecks"
 	"github.com/criteo/command-launcher/internal/command"
 	"gopkg.in/yaml.v3"
 )
@@ -145,6 +146,10 @@ func ExecSetupHookFromPackage(pkg command.PackageManifest, pkgDir string) error 
 		if c.Name() == "__setup__" && c.Type() == "system" {
 			if pkgDir != "" {
 				c.SetPackageDir(pkgDir)
+			}
+			prechecksUrls := c.PrecheckURLs()
+			if err := prechecks.PrecheckURLsAccess(prechecksUrls); err != nil {
+				return fmt.Errorf("setup hook of package %s cannot be executed because pre-checks failed: %v", pkg.Name(), err)
 			}
 			// Execute the __setup__ hook
 			_, err := c.Execute(os.Environ())

--- a/internal/pkg/zip-package.go
+++ b/internal/pkg/zip-package.go
@@ -55,12 +55,13 @@ func (pkg *zipPackage) InstallTo(targetDir string) (command.PackageManifest, err
 		}
 	}
 
+	var err error
 	if viper.GetBool(config.ENABLE_PACKAGE_SETUP_HOOK_KEY) {
 		// for now ignore the setup error
-		pkg.RunSetup(targetDir)
+		err = pkg.RunSetup(targetDir)
 	}
 
-	return pkg.Manifest, nil
+	return pkg.Manifest, err
 }
 
 func (pkg *zipPackage) VerifyChecksum(checksum string) (bool, error) {


### PR DESCRIPTION
The purpose of `precheckURLs` is to check access of external endpoints before running command. It can be useful to test access of resources before installing packages.

Test and documentation included in the PR.