### PR TITLE
Set version for Github Action zip package plugin

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -139,7 +139,7 @@ jobs:
           mv output/windows/amd64/cdt_windows_amd64_${{needs.build.outputs.sha_short}} output/windows/amd64/cdt.exe
 
       - name: Zip the package
-        uses: thedoctor0/zip-release@master
+        uses: thedoctor0/zip-release@0.7.6
         if: startsWith(github.ref, 'refs/tags/')
         with:
           type: 'zip'


### PR DESCRIPTION
Due to security issue in unverified plugin, set a static version on zip plugin.