### PR TITLE
Add package inspect command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 *.swp
 test/metrics.txt
 cdt
+.claude/

--- a/cmd/package-mgmt.go
+++ b/cmd/package-mgmt.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/criteo/command-launcher/internal/backend"
 	"github.com/criteo/command-launcher/internal/command"
 	"github.com/criteo/command-launcher/internal/config"
@@ -422,7 +424,9 @@ func printPackageDetails(pkg command.PackageManifest, source *backend.PackageSou
 	if source.IsManaged {
 		paused := false
 		pausedUntil := time.Time{}
-		if exists, _ := updateConfig.IsUpdateConfigExists(source.RepoDir); exists {
+		if exists, err := updateConfig.IsUpdateConfigExists(source.RepoDir); err != nil {
+			log.Warnf("failed to check update config in %s: %v", source.RepoDir, err)
+		} else if exists {
 			if cfg, err := updateConfig.ReadFromDir(source.RepoDir); err == nil {
 				if cfg.IsPackagePaused(pkg.Name()) {
 					paused = true

--- a/cmd/package-mgmt.go
+++ b/cmd/package-mgmt.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/criteo/command-launcher/internal/backend"
 	"github.com/criteo/command-launcher/internal/command"
 	"github.com/criteo/command-launcher/internal/config"
 	"github.com/criteo/command-launcher/internal/console"
@@ -15,6 +17,7 @@ import (
 	"github.com/criteo/command-launcher/internal/pkg"
 	"github.com/criteo/command-launcher/internal/remote"
 	"github.com/criteo/command-launcher/internal/repository"
+	"github.com/criteo/command-launcher/internal/updateConfig"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -158,6 +161,19 @@ To enable the automatic setup during package installation, enable the configurat
 		ValidArgsFunction: packageNameValidatonFunc(true, true, false),
 	}
 
+	packageInspectCmd := &cobra.Command{
+		Use:   "inspect [package_name]",
+		Short: "Show details of an installed package",
+		Long:  "Show detailed information about an installed package including its source, version, local path, pause status, and commands",
+		Args:  cobra.ExactArgs(1),
+		Example: fmt.Sprintf(`
+  %s package inspect my-pkg`, appCtx.AppName()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return inspectPackage(args[0])
+		},
+		ValidArgsFunction: packageNameValidatonFunc(true, true, false),
+	}
+
 	packagePauseCmd := &cobra.Command{
 		Use:   "pause [package_name]",
 		Short: "Pause update for a package",
@@ -181,23 +197,25 @@ To enable the automatic setup during package installation, enable the configurat
 	packageCmd.AddCommand(packageDeleteCmd)
 	packageCmd.AddCommand(packageSetupCmd)
 	packageCmd.AddCommand(packagePauseCmd)
+	packageCmd.AddCommand(packageInspectCmd)
 	rootCmd.AddCommand(packageCmd)
 }
 
 func packageNameValidatonFunc(includeLocal bool, includeDropin bool, includeRemote bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		localPkgs := rootCtxt.backend.DefaultRepository().InstalledPackages()
-		dropinPkgs := rootCtxt.backend.DropinRepository().InstalledPackages()
-
 		pkgTable := map[string]string{}
 
 		if includeLocal {
-			for _, pkg := range localPkgs {
-				pkgTable[pkg.Name()] = pkg.Version()
+			for _, s := range rootCtxt.backend.AllPackageSources() {
+				if s.IsManaged && s.Repo != nil {
+					for _, pkg := range s.Repo.InstalledPackages() {
+						pkgTable[pkg.Name()] = pkg.Version()
+					}
+				}
 			}
 		}
 		if includeDropin {
-			for _, pkg := range dropinPkgs {
+			for _, pkg := range rootCtxt.backend.DropinRepository().InstalledPackages() {
 				pkgTable[pkg.Name()] = pkg.Version()
 			}
 		}
@@ -227,12 +245,17 @@ func noArgCompletion(cmd *cobra.Command, args []string, toComplete string) ([]st
 func printPackages(repo repository.PackageRepository, name string, includeCmd bool) {
 	console.Highlight("=== %s ===\n", strings.Title(name))
 	for _, pkg := range repo.InstalledPackages() {
-		fmt.Printf("  - %-50s %s\n", pkg.Name(), pkg.Version())
 		if includeCmd {
+			fmt.Printf("  Package: %s (v%s)\n", pkg.Name(), pkg.Version())
 			printCommands(pkg.Commands())
+			fmt.Println()
+		} else {
+			fmt.Printf("  - %-50s %s\n", pkg.Name(), pkg.Version())
 		}
 	}
-	fmt.Println()
+	if !includeCmd {
+		fmt.Println()
+	}
 }
 
 func printPackageInfos(packages []remote.PackageInfo, name string) {
@@ -246,10 +269,12 @@ func printPackageInfos(packages []remote.PackageInfo, name string) {
 func printCommands(commands []command.Command) {
 	cmdMap := make(map[string][]command.Command)
 	cmdMap["__no_group__"] = make([]command.Command, 0)
+	groupDescs := make(map[string]string)
 
 	for _, cmd := range commands {
 		if cmd.Type() == "group" {
 			cmdMap[cmd.Name()] = make([]command.Command, 0)
+			groupDescs[cmd.Name()] = cmd.ShortDescription()
 		} else if cmd.Type() == "executable" {
 			if cmd.Group() != "" {
 				cmdMap[cmd.Group()] = append(cmdMap[cmd.Group()], cmd)
@@ -261,9 +286,19 @@ func printCommands(commands []command.Command) {
 
 	for g, cs := range cmdMap {
 		if len(cmdMap[g]) > 0 {
-			fmt.Printf("%4s %-49s %s\n", "*", g, "(group)")
+			desc := groupDescs[g]
+			if desc != "" {
+				fmt.Printf("%4s %-30s %s\n", "*", g, desc)
+			} else {
+				fmt.Printf("%4s %s\n", "*", g)
+			}
 			for _, c := range cs {
-				fmt.Printf("%6s %-47s %s\n", "-", c.Name(), "(cmd)")
+				cmdDesc := c.ShortDescription()
+				if cmdDesc != "" {
+					fmt.Printf("%6s %-28s %s\n", "-", c.Name(), cmdDesc)
+				} else {
+					fmt.Printf("%6s %s\n", "-", c.Name())
+				}
 			}
 		}
 	}
@@ -331,6 +366,79 @@ func installZipFile(fileUrl string) error {
 
 	console.Success("Package '%s' version %s installed in the dropin repository", mf.Name(), mf.Version())
 	return nil
+}
+
+type packageMatch struct {
+	pkg    command.PackageManifest
+	source *backend.PackageSource
+}
+
+func inspectPackage(pkgName string) error {
+	matches := []packageMatch{}
+
+	for _, s := range rootCtxt.backend.AllPackageSources() {
+		if s.Repo == nil {
+			continue
+		}
+		for _, p := range s.Repo.InstalledPackages() {
+			if p.Name() == pkgName {
+				matches = append(matches, packageMatch{pkg: p, source: s})
+				break
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("no package named %s found", pkgName)
+	}
+
+	for i, m := range matches {
+		if i > 0 {
+			fmt.Println()
+		}
+		printPackageDetails(m.pkg, m.source)
+	}
+
+	return nil
+}
+
+func printPackageDetails(pkg command.PackageManifest, source *backend.PackageSource) {
+	console.Highlight("Package: %s (source: %s)\n", pkg.Name(), source.Name)
+	fmt.Printf("  Full Name:  %s@%s\n", pkg.Name(), source.Name)
+	fmt.Printf("  Version:    %s\n", pkg.Version())
+	fmt.Printf("  Source:     %s\n", source.Name)
+	fmt.Printf("  Managed:    %v\n", source.IsManaged)
+
+	if source.IsManaged {
+		fmt.Printf("  Remote URL: %s\n", source.RemoteBaseURL)
+		fmt.Printf("  Registry:   %s\n", source.RemoteRegistryURL)
+		fmt.Printf("  Sync:       %s\n", source.SyncPolicy)
+	}
+
+	if repoFolder, err := source.Repo.RepositoryFolder(); err == nil {
+		fmt.Printf("  Local Path: %s\n", repoFolder)
+	}
+
+	if source.IsManaged {
+		paused := false
+		pausedUntil := time.Time{}
+		if exists, _ := updateConfig.IsUpdateConfigExists(source.RepoDir); exists {
+			if cfg, err := updateConfig.ReadFromDir(source.RepoDir); err == nil {
+				if cfg.IsPackagePaused(pkg.Name()) {
+					paused = true
+					pausedUntil = cfg.PausedUntil[pkg.Name()]
+				}
+			}
+		}
+		fmt.Printf("  Paused:     %v\n", paused)
+		if paused {
+			fmt.Printf("  Paused Until: %s\n", pausedUntil.Format(time.RFC3339))
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("  Commands:")
+	printCommands(pkg.Commands())
 }
 
 func findPackageFolder(pkgName string) (string, error) {

--- a/test/integration/test-package-management.sh
+++ b/test/integration/test-package-management.sh
@@ -125,17 +125,17 @@ fi
 echo "> test list local --include-cmd"
 RESULT=$($CL_PATH package list --local --include-cmd)
 
-echo "* should contain package version"
-echo "$RESULT" | grep -q "1.0.0"
+echo "* should contain package with version"
+echo "$RESULT" | grep -q "Package: command-launcher-demo (v1.0.0)"
 if [ $? -eq 0 ]; then
   echo "OK"
 else
-  echo "KO - should contain package version"
+  echo "KO - should contain package with version"
   exit 1
 fi
 
 echo "* should contain group"
-echo "$RESULT" | grep -q "* __no_group__                                      (group)"
+echo "$RESULT" | grep -q "\* __no_group__"
 if [ $? -eq 0 ]; then
   echo "OK"
 else
@@ -144,7 +144,7 @@ else
 fi
 
 echo "* should contain command"
-echo "$RESULT" | grep -q "\- hello                                           (cmd)"
+echo "$RESULT" | grep -q "\- hello"
 if [ $? -eq 0 ]; then
   echo "OK"
 else
@@ -157,7 +157,7 @@ echo "> test list dropin --include-cmd"
 RESULT=$($CL_PATH package list --dropin --include-cmd)
 
 echo "* should contain package version"
-echo "$RESULT" | grep -q "\- bonjour                                            1.0.0"
+echo "$RESULT" | grep -q "Package: bonjour (v1.0.0)"
 if [ $? -eq 0 ]; then
   echo "OK"
 else
@@ -166,7 +166,7 @@ else
 fi
 
 echo "* should contain group"
-echo "$RESULT" | grep -q "* __no_group__                                      (group)"
+echo "$RESULT" | grep -q "\* __no_group__"
 if [ $? -eq 0 ]; then
   echo "OK"
 else
@@ -175,7 +175,7 @@ else
 fi
 
 echo "* should contain command"
-echo "$RESULT" | grep -q "\- bonjour                                         (cmd)"
+echo "$RESULT" | grep -q "\- bonjour"
 if [ $? -eq 0 ]; then
   echo "OK"
 else
@@ -206,12 +206,132 @@ else
 fi
 
 ################
+echo "> test inspect dropin package"
+RESULT=$($CL_PATH package inspect bonjour)
+
+echo "* should contain package name"
+echo "$RESULT" | grep -q "Package: bonjour"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should contain package name"
+  exit 1
+fi
+
+echo "* should contain version"
+echo "$RESULT" | grep -q "Version:.*1.0.0"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should contain version"
+  exit 1
+fi
+
+echo "* should show full name"
+echo "$RESULT" | grep -q "Full Name:.*bonjour@dropin"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should show full name bonjour@dropin"
+  exit 1
+fi
+
+echo "* should show source as dropin"
+echo "$RESULT" | grep -q "Source:.*dropin"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should show source as dropin"
+  exit 1
+fi
+
+echo "* should show managed as false"
+echo "$RESULT" | grep -q "Managed:.*false"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should show managed as false"
+  exit 1
+fi
+
+echo "* should contain commands section"
+echo "$RESULT" | grep -q "Commands:"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should contain commands section"
+  exit 1
+fi
+
+################
+echo "> test inspect managed package"
+RESULT=$($CL_PATH package inspect command-launcher-demo)
+
+echo "* should contain package name"
+echo "$RESULT" | grep -q "Package: command-launcher-demo"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should contain package name"
+  exit 1
+fi
+
+echo "* should show full name"
+echo "$RESULT" | grep -q "Full Name:.*command-launcher-demo@default"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should show full name command-launcher-demo@default"
+  exit 1
+fi
+
+echo "* should show managed as true"
+echo "$RESULT" | grep -q "Managed:.*true"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should show managed as true"
+  exit 1
+fi
+
+echo "* should show sync policy"
+echo "$RESULT" | grep -q "Sync:"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should show sync policy"
+  exit 1
+fi
+
+################
+echo "> test inspect nonexistent package"
+RESULT=$($CL_PATH package inspect nonexistent-pkg 2>&1)
+EXIT_CODE=$?
+
+echo "* should fail with error"
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "OK"
+else
+  echo "KO - should fail for nonexistent package"
+  exit 1
+fi
+
+echo "* should contain error message"
+echo "$RESULT" | grep -q "no package named nonexistent-pkg found"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should contain error message"
+  exit 1
+fi
+
+################
 echo "> test install git package"
 RESULT=$($CL_PATH package install --git https://github.com/criteo/command-launcher-package-example)
 RESULT=$($CL_PATH package list --dropin --include-cmd)
 
 echo "* should contain package from git repo"
-echo "$RESULT" | grep -q "\- command-launcher-example-package                   0.0.1"
+echo "$RESULT" | grep -q "Package: command-launcher-example-package (v0.0.1)"
 if [ $? -eq 0 ]; then
   echo "OK"
 else
@@ -220,7 +340,7 @@ else
 fi
 
 echo "* should contain group command from git repo"
-echo "$RESULT" | grep -q "* cola-example                                      (group)"
+echo "$RESULT" | grep -q "\* cola-example"
 if [ $? -eq 0 ]; then
   echo "OK"
 else
@@ -229,7 +349,7 @@ else
 fi
 
 echo "* should contain greeting command from git repo"
-echo "$RESULT" | grep -q "\- greeting                                        (cmd)"
+echo "$RESULT" | grep -q "\- greeting"
 if [ $? -eq 0 ]; then
   echo "OK"
 else
@@ -249,7 +369,7 @@ fi
 
 echo "* should NOT contain package from git repo"
 RESULT=$($CL_PATH package list --dropin --include-cmd)
-echo "$RESULT" | grep -q "\- command-launcher-example-package                   0.0.1"
+echo "$RESULT" | grep -q "Package: command-launcher-example-package (v0.0.1)"
 if [ $? -ne 0 ]; then
   echo "OK"
 else
@@ -263,7 +383,7 @@ RESULT=$($CL_PATH package install --file https://github.com/criteo/command-launc
 
 echo "* should contain 2.0.0 demo package"
 RESULT=$($CL_PATH package list --dropin --include-cmd)
-echo "$RESULT" | grep -q "\- command-launcher-demo                              2.0.0"
+echo "$RESULT" | grep -q "Package: command-launcher-demo (v2.0.0)"
 if [ $? -eq 0 ]; then
   echo "OK"
 else


### PR DESCRIPTION
So far in the built-in `package` command, we can list all the packages and show their commands in it. However, it doesn't provide enough metadata of the package. for example, which repository it is, what version it is, etc. It makes debugging very difficult.
This inspect command accepts a pacakge name (support auto-completion), will list all the packages with the same name in different local repository. For each package, list their metadatas. So far it prints:
- Full Name
- Version
- Remote Registry (Source)
- Remote Registry URL
- Sync Policy
- Local Repository Path
- If it has been paused