### PR TITLE
Support workspace and project scope package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 *.swp
 test/metrics.txt
 cdt
+.claude/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ go build -o cdt -ldflags='-X main.version=dev -X main.appName=cdt -X "main.appLo
 
 Or simply call the `build.sh` scripts
 ```
-./build.sh [version] [app name] [app long name]
+./build.sh [version] [app name] [app long name] [--resign]
+```
+
+On macOS (Apple Silicon), copying the built binary to another location may invalidate its ad-hoc code signature, causing the system to kill the process. Use the `--resign` flag to re-sign the binary after build:
+```
+./build.sh dev cdt "Criteo Dev Toolkit" --resign
 ```
 
 ### Run tests

--- a/build.sh
+++ b/build.sh
@@ -5,5 +5,10 @@ DEFAULT_VERSION=$(git rev-parse --abbrev-ref HEAD)-dev
 VERSION=${1:-$DEFAULT_VERSION}
 APP_NAME=${2:-cdt}
 APP_LONG_NAME=${3:-Criteo Dev Toolkit}
+RESIGN=${4:-}
 
 go build -o $APP_NAME -ldflags="-X main.version=$VERSION -X main.buildNum=$(date +'%Y%m%d-%H%M%S') -X main.appName=$APP_NAME -X 'main.appLongName=$APP_LONG_NAME'"
+
+if [ "$RESIGN" = "--resign" ] && [ "$(uname)" = "Darwin" ]; then
+    codesign --force -s - "$APP_NAME"
+fi

--- a/cmd/consent/workspace-consent.go
+++ b/cmd/consent/workspace-consent.go
@@ -16,35 +16,38 @@ import (
 // from a workspace at the given directory path.
 // Returns true if consent exists and is not expired.
 func CheckWorkspaceConsent(workspaceDir string) bool {
-	key := workspaceConsentKey(workspaceDir)
-	secretValue, err := helper.GetSecret(key)
+	consent, err := getWorkspaceConsent(workspaceDir)
 	if err != nil {
 		return false
 	}
+	return hasConsentValue(consent, "workspace")
+}
 
-	var consent Consent
-	if err := json.Unmarshal([]byte(secretValue), &consent); err != nil {
+// IsWorkspaceConsentDenied checks if the user has explicitly denied consent
+// for a workspace. Returns true if a non-expired denial record exists.
+func IsWorkspaceConsentDenied(workspaceDir string) bool {
+	consent, err := getWorkspaceConsent(workspaceDir)
+	if err != nil {
 		return false
 	}
-
-	if time.Unix(consent.ExpiresAt, 0).Before(time.Now()) {
-		return false
-	}
-
-	return true
+	return hasConsentValue(consent, "denied")
 }
 
 // RequestWorkspaceConsent prompts the user to trust a workspace.
 // Displays the workspace path and asks for y/N confirmation.
 // On approval, saves consent with expiration from USER_CONSENT_LIFE_KEY config.
+// On denial, saves denial with the same expiration.
 func RequestWorkspaceConsent(workspaceDir string) bool {
-	fmt.Printf("Workspace commands discovered at: %s\n", workspaceDir)
-	console.Reminder("Do you trust and want to load commands from this workspace? [yN]")
+	fmt.Printf("This command is provided by workspace: %s\n", workspaceDir)
+	console.Reminder("Do you trust and want to run commands from this workspace? [yN]")
 
 	var resp int
 	if _, err := fmt.Scanf("%c", &resp); err != nil || (resp != 'y' && resp != 'Y') {
-		fmt.Printf("Workspace commands not loaded.\n")
+		fmt.Printf("Workspace command execution denied.\n")
 		fmt.Printf("-----------------------------\n\n")
+		if err := saveWorkspaceConsentRecord(workspaceDir, "denied"); err != nil {
+			fmt.Printf("Warning: failed to save workspace denial: %v\n", err)
+		}
 		return false
 	}
 
@@ -57,6 +60,10 @@ func RequestWorkspaceConsent(workspaceDir string) bool {
 
 // SaveWorkspaceConsent persists consent for a workspace directory.
 func SaveWorkspaceConsent(workspaceDir string) error {
+	return saveWorkspaceConsentRecord(workspaceDir, "workspace")
+}
+
+func saveWorkspaceConsentRecord(workspaceDir string, consentType string) error {
 	keyLife := viper.GetDuration(config.USER_CONSENT_LIFE_KEY).Seconds()
 	if keyLife <= 0 {
 		// default: 30 days
@@ -66,13 +73,41 @@ func SaveWorkspaceConsent(workspaceDir string) error {
 	key := workspaceConsentKey(workspaceDir)
 	secretValue, err := json.Marshal(Consent{
 		ExpiresAt: time.Now().Unix() + int64(keyLife),
-		Consents:  []string{"workspace"},
+		Consents:  []string{consentType},
 	})
 	if err != nil {
 		return err
 	}
 
 	return helper.SetSecret(key, string(secretValue))
+}
+
+func getWorkspaceConsent(workspaceDir string) (*Consent, error) {
+	key := workspaceConsentKey(workspaceDir)
+	secretValue, err := helper.GetSecret(key)
+	if err != nil {
+		return nil, err
+	}
+
+	var consent Consent
+	if err := json.Unmarshal([]byte(secretValue), &consent); err != nil {
+		return nil, err
+	}
+
+	if time.Unix(consent.ExpiresAt, 0).Before(time.Now()) {
+		return nil, fmt.Errorf("consent expired")
+	}
+
+	return &consent, nil
+}
+
+func hasConsentValue(consent *Consent, value string) bool {
+	for _, c := range consent.Consents {
+		if c == value {
+			return true
+		}
+	}
+	return false
 }
 
 // workspaceConsentKey returns a keychain key for the workspace directory.

--- a/cmd/consent/workspace-consent.go
+++ b/cmd/consent/workspace-consent.go
@@ -1,0 +1,83 @@
+package consent
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/criteo/command-launcher/internal/config"
+	"github.com/criteo/command-launcher/internal/console"
+	"github.com/criteo/command-launcher/internal/helper"
+	"github.com/spf13/viper"
+)
+
+// CheckWorkspaceConsent checks if the user has consented to run commands
+// from a workspace at the given directory path.
+// Returns true if consent exists and is not expired.
+func CheckWorkspaceConsent(workspaceDir string) bool {
+	key := workspaceConsentKey(workspaceDir)
+	secretValue, err := helper.GetSecret(key)
+	if err != nil {
+		return false
+	}
+
+	var consent Consent
+	if err := json.Unmarshal([]byte(secretValue), &consent); err != nil {
+		return false
+	}
+
+	if time.Unix(consent.ExpiresAt, 0).Before(time.Now()) {
+		return false
+	}
+
+	return true
+}
+
+// RequestWorkspaceConsent prompts the user to trust a workspace.
+// Displays the workspace path and asks for y/N confirmation.
+// On approval, saves consent with expiration from USER_CONSENT_LIFE_KEY config.
+func RequestWorkspaceConsent(workspaceDir string) bool {
+	fmt.Printf("Workspace commands discovered at: %s\n", workspaceDir)
+	console.Reminder("Do you trust and want to load commands from this workspace? [yN]")
+
+	var resp int
+	if _, err := fmt.Scanf("%c", &resp); err != nil || (resp != 'y' && resp != 'Y') {
+		fmt.Printf("Workspace commands not loaded.\n")
+		fmt.Printf("-----------------------------\n\n")
+		return false
+	}
+
+	if err := SaveWorkspaceConsent(workspaceDir); err != nil {
+		fmt.Printf("Warning: failed to save workspace consent: %v\n", err)
+	}
+
+	return true
+}
+
+// SaveWorkspaceConsent persists consent for a workspace directory.
+func SaveWorkspaceConsent(workspaceDir string) error {
+	keyLife := viper.GetDuration(config.USER_CONSENT_LIFE_KEY).Seconds()
+	if keyLife <= 0 {
+		// default: 30 days
+		keyLife = 2592000
+	}
+
+	key := workspaceConsentKey(workspaceDir)
+	secretValue, err := json.Marshal(Consent{
+		ExpiresAt: time.Now().Unix() + int64(keyLife),
+		Consents:  []string{"workspace"},
+	})
+	if err != nil {
+		return err
+	}
+
+	return helper.SetSecret(key, string(secretValue))
+}
+
+// workspaceConsentKey returns a keychain key for the workspace directory.
+// Uses sha256 hash of the absolute path to avoid special characters.
+func workspaceConsentKey(workspaceDir string) string {
+	hash := sha256.Sum256([]byte(workspaceDir))
+	return fmt.Sprintf("workspace_consent_%x", hash[:8])
+}

--- a/cmd/package-mgmt.go
+++ b/cmd/package-mgmt.go
@@ -25,6 +25,7 @@ type PackageFlags struct {
 	dropin     bool
 	local      bool
 	remote     bool
+	workspace  bool
 	includeCmd bool
 }
 
@@ -49,13 +50,22 @@ func AddPackageCmd(rootCmd *cobra.Command, appCtx context.LauncherContext) {
 		Short: "List installed packages and commands",
 		Long:  "List installed packages and commands with details",
 		PreRun: func(cmd *cobra.Command, args []string) {
-			if !packageFlags.dropin && !packageFlags.local && !packageFlags.remote {
+			if !packageFlags.dropin && !packageFlags.local && !packageFlags.remote && !packageFlags.workspace {
 				packageFlags.dropin = true
 				packageFlags.local = true
 				packageFlags.remote = false
+				packageFlags.workspace = true
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			if packageFlags.workspace {
+				for _, s := range rootCtxt.backend.WorkspaceSources() {
+					if s.Repo != nil {
+						printPackages(s.Repo, fmt.Sprintf("workspace: %s", s.RepoDir), packageFlags.includeCmd)
+					}
+				}
+			}
+
 			if packageFlags.local {
 				for _, s := range rootCtxt.backend.AllPackageSources() {
 					if s.IsManaged && s.Repo != nil {
@@ -86,9 +96,10 @@ func AddPackageCmd(rootCmd *cobra.Command, appCtx context.LauncherContext) {
 	packageListCmd.Flags().BoolVar(&packageFlags.dropin, "dropin", false, "List only the dropin packages")
 	packageListCmd.Flags().BoolVar(&packageFlags.local, "local", false, "List only the local packages")
 	packageListCmd.Flags().BoolVar(&packageFlags.remote, "remote", false, "List only the remote packages")
+	packageListCmd.Flags().BoolVar(&packageFlags.workspace, "workspace", false, "List only the workspace packages")
 	packageListCmd.Flags().BoolVar(&packageFlags.includeCmd, "include-cmd", false, "List the packages with all commands")
 	packageListCmd.Flags().BoolP("all", "a", true, "List all packages")
-	packageListCmd.MarkFlagsMutuallyExclusive("all", "dropin", "local", "remote")
+	packageListCmd.MarkFlagsMutuallyExclusive("all", "dropin", "local", "remote", "workspace")
 
 	packageInstallCmd := &cobra.Command{
 		Use:   "install [package_name]",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,11 +36,10 @@ type rootContext struct {
 	metrics     metrics.Metrics
 }
 
-// builtinCommands lists commands that are built into the launcher and should
-// be excluded from auto-update checks and workspace consent prompts.
+// builtinCommands lists commands that are excluded from auto-update checks
+// and metrics collection.
 var builtinCommands = []string{
 	"version", "config", "completion", "help", "update",
-	"package", "login", "remote", "rename",
 	"__complete", "__completeNoDesc",
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,14 @@ type rootContext struct {
 	metrics     metrics.Metrics
 }
 
+// builtinCommands lists commands that are built into the launcher and should
+// be excluded from auto-update checks and workspace consent prompts.
+var builtinCommands = []string{
+	"version", "config", "completion", "help", "update",
+	"package", "login", "remote", "rename",
+	"__complete", "__completeNoDesc",
+}
+
 var (
 	rootCmd  *cobra.Command
 	rootCtxt = rootContext{}
@@ -137,9 +145,7 @@ func postRun(cmd *cobra.Command, args []string) {
 func isUpdatePossible(cmd *cobra.Command) bool {
 	cmdPath := cmd.CommandPath()
 	cmdPath = strings.TrimSpace(strings.TrimPrefix(cmdPath, rootCtxt.appCtx.AppName()))
-	// exclude commands for update check
-	// for example version command, you don't want to check new update when requesting current version
-	for _, w := range []string{"version", "config", "completion", "help", "update", "__complete"} {
+	for _, w := range builtinCommands {
 		if strings.HasPrefix(cmdPath, w) {
 			return false
 		}
@@ -159,6 +165,7 @@ func cmdUpdateEnabled(cmd *cobra.Command, args []string) bool {
 func metricsEnabled(cmd *cobra.Command, args []string) bool {
 	return viper.GetBool(config.USAGE_METRICS_ENABLED_KEY) && isUpdatePossible(cmd)
 }
+
 
 func initUser() {
 	var err error = nil
@@ -208,12 +215,15 @@ func initBackend() {
 		))
 	}
 
-	// Discover workspace packages if enabled
+	// Discover workspace packages if enabled.
+	// Sources with prior denial are excluded. Sources without any consent
+	// record are loaded so their commands appear in autocompletion; consent
+	// is checked at execution time.
 	workspaceSources := []*backend.PackageSource{}
 	if viper.GetBool(config.ENABLE_WORKSPACE_PACKAGES_KEY) {
 		wd, _ := os.Getwd()
 		for _, src := range backend.DiscoverWorkspaceSources(wd, rootCtxt.appCtx.AppName()) {
-			if consent.CheckWorkspaceConsent(src.RepoDir) || consent.RequestWorkspaceConsent(src.RepoDir) {
+			if !consent.IsWorkspaceConsentDenied(src.RepoDir) {
 				workspaceSources = append(workspaceSources, src)
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -220,7 +220,10 @@ func initBackend() {
 	// is checked at execution time.
 	workspaceSources := []*backend.PackageSource{}
 	if viper.GetBool(config.ENABLE_WORKSPACE_PACKAGES_KEY) {
-		wd, _ := os.Getwd()
+		wd, err := os.Getwd()
+		if err != nil {
+			log.Warnf("workspace packages: failed to get working directory: %v", err)
+		}
 		for _, src := range backend.DiscoverWorkspaceSources(wd, rootCtxt.appCtx.AppName()) {
 			if !consent.IsWorkspaceConsentDenied(src.RepoDir) {
 				workspaceSources = append(workspaceSources, src)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -212,7 +212,7 @@ func initBackend() {
 	workspaceSources := []*backend.PackageSource{}
 	if viper.GetBool(config.ENABLE_WORKSPACE_PACKAGES_KEY) {
 		wd, _ := os.Getwd()
-		for _, src := range backend.DiscoverWorkspaceSources(wd) {
+		for _, src := range backend.DiscoverWorkspaceSources(wd, rootCtxt.appCtx.AppName()) {
 			if consent.CheckWorkspaceConsent(src.RepoDir) || consent.RequestWorkspaceConsent(src.RepoDir) {
 				workspaceSources = append(workspaceSources, src)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/criteo/command-launcher/cmd/consent"
 	"github.com/criteo/command-launcher/cmd/metrics"
 	"github.com/criteo/command-launcher/internal/backend"
 	"github.com/criteo/command-launcher/internal/config"
@@ -207,9 +208,21 @@ func initBackend() {
 		))
 	}
 
+	// Discover workspace packages if enabled
+	workspaceSources := []*backend.PackageSource{}
+	if viper.GetBool(config.ENABLE_WORKSPACE_PACKAGES_KEY) {
+		wd, _ := os.Getwd()
+		for _, src := range backend.DiscoverWorkspaceSources(wd) {
+			if consent.CheckWorkspaceConsent(src.RepoDir) || consent.RequestWorkspaceConsent(src.RepoDir) {
+				workspaceSources = append(workspaceSources, src)
+			}
+		}
+	}
+
 	var err error
 	rootCtxt.backend, err = backend.NewDefaultBackend(
 		config.AppDir(),
+		workspaceSources,
 		backend.NewDropinSource(viper.GetString(config.DROPIN_FOLDER_KEY)),
 		backend.NewManagedSource(
 			"default",

--- a/gh-pages/content/en/docs/overview/workspace.md
+++ b/gh-pages/content/en/docs/overview/workspace.md
@@ -51,7 +51,7 @@ scripts/dev-helpers
 
 Each path listed in the packages file must be a directory containing a `manifest.mf` file, following the standard [manifest format](../manifest). The directory structure looks like this:
 
-```
+```text
 my-project/
 ├── .cdt-packages          # lists package paths
 ├── src/
@@ -92,7 +92,7 @@ When you run Command Launcher, it walks **up** from your current working directo
 
 For example, given this directory tree:
 
-```
+```text
 /home/user/
 ├── .cdt-packages          # project-wide tools
 └── repo/
@@ -122,7 +122,7 @@ Because workspace packages contain arbitrary scripts that execute on your machin
 
 When you invoke a workspace command, you will see a prompt like:
 
-```
+```text
 This command is provided by workspace: /home/user/my-project
 Do you trust and want to run commands from this workspace? [yN]
 ```
@@ -236,6 +236,7 @@ Hello from workspace!
 ## Troubleshooting
 
 **Commands not showing up:**
+
 - Verify the feature is enabled: `cdt config ENABLE_WORKSPACE_PACKAGES`
 - Check that you are running `cdt` from inside the workspace (or a subdirectory)
 - Ensure the `.cdt-packages` file name matches your app name (e.g., `.cola-packages` for `cola`)
@@ -243,10 +244,13 @@ Hello from workspace!
 - Enable logging for detailed diagnostics: `cdt config LOG_ENABLED true && cdt config LOG_LEVEL debug`
 
 **Consent prompt keeps appearing:**
+
 - The consent has expired. Increase the duration with `cdt config USER_CONSENT_LIFE 2160h` (90 days).
 
 **Command was denied and now it's hidden:**
+
 - Denial is remembered for the configured `USER_CONSENT_LIFE` duration. Wait for it to expire, or the consent will reset automatically after the configured period.
 
 **Path rejected with "parent directory traversal" warning:**
+
 - Paths in `.cdt-packages` must not contain `..`. Use paths relative to the packages file location that point downward into the project tree.

--- a/gh-pages/content/en/docs/overview/workspace.md
+++ b/gh-pages/content/en/docs/overview/workspace.md
@@ -1,0 +1,252 @@
+---
+title: "Workspace package"
+description: "Project-scoped commands that are automatically discovered from your workspace"
+lead: "Project-scoped commands that are automatically discovered from your workspace"
+date: 2024-01-01T00:00:00+00:00
+lastmod: 2024-01-01T00:00:00+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "overview"
+    identifier: "workspace-d1a2b3c4e5f6a7b8c9d0e1f2a3b4c5d6"
+weight: 247
+toc: true
+---
+
+## What are workspace packages?
+
+Workspace packages are command packages that live inside your project directory and are automatically discovered when you run Command Launcher from within that project. Unlike [dropin packages](../dropin) (which are global to your machine) or managed packages (which come from a remote repository), workspace packages are **scoped to a specific project** and are only visible when your working directory is inside that project.
+
+This is useful for:
+
+- **Project-specific tooling** — build scripts, deployment helpers, or dev workflows that only make sense for a particular project
+- **Team-shared commands** — check the packages and the `.cdt-packages` file into version control so every team member gets the same CLI tools
+- **Quick prototyping** — develop and test new commands directly in your project without touching the global dropin folder
+
+## Enabling workspace packages
+
+Workspace packages are disabled by default. Enable the feature with:
+
+```shell
+cdt config ENABLE_WORKSPACE_PACKAGES true
+```
+
+## Setting up a workspace
+
+### 1. Create a packages file
+
+Create a file named **`.cdt-packages`** in your project root (the file name matches your app name — if your binary is called `cola`, the file is `.cola-packages`).
+
+This file lists the relative paths to your package directories, one per line:
+
+```text
+# Lines starting with # are comments
+tools/my-build-tool
+tools/my-deploy-tool
+scripts/dev-helpers
+```
+
+### 2. Create package directories
+
+Each path listed in the packages file must be a directory containing a `manifest.mf` file, following the standard [manifest format](../manifest). The directory structure looks like this:
+
+```
+my-project/
+├── .cdt-packages          # lists package paths
+├── src/
+│   └── ...
+└── tools/
+    ├── my-build-tool/
+    │   ├── manifest.mf    # command definitions
+    │   └── build.sh       # scripts
+    └── my-deploy-tool/
+        ├── manifest.mf
+        └── deploy.sh
+```
+
+### 3. Write a manifest
+
+A workspace package manifest is identical to a dropin or managed package manifest. Here is a minimal example:
+
+```json
+{
+  "pkgName": "my-build-tool",
+  "version": "1.0.0",
+  "cmds": [
+    {
+      "name": "build",
+      "type": "executable",
+      "short": "Build the project",
+      "executable": "{{.PackageDir}}/build.sh"
+    }
+  ]
+}
+```
+
+See the [manifest reference](../manifest) for the full list of supported fields (flags, auto-completion, groups, etc.).
+
+## How discovery works
+
+When you run Command Launcher, it walks **up** from your current working directory toward the filesystem root, looking for `.cdt-packages` files at each level. Every matching file is loaded, with **deepest-first** priority — packages found closer to your working directory take precedence over those found higher up.
+
+For example, given this directory tree:
+
+```
+/home/user/
+├── .cdt-packages          # project-wide tools
+└── repo/
+    ├── .cdt-packages      # repo-specific tools (higher priority)
+    └── src/
+        └── (you are here)
+```
+
+If you run `cdt` from `/home/user/repo/src/`, both packages files are discovered. Commands from `/home/user/repo/.cdt-packages` take priority over those from `/home/user/.cdt-packages`.
+
+### Priority order
+
+Workspace packages have the **highest** priority among all package sources:
+
+1. **Workspace packages** (deepest-first) — highest priority
+2. **Dropin packages**
+3. **Default managed packages**
+4. **Extra remote packages** — lowest priority
+
+If a workspace command has the same name as a command from another source, the workspace command wins.
+
+## Security
+
+### Consent prompt
+
+Because workspace packages contain arbitrary scripts that execute on your machine, Command Launcher requires your **explicit consent** before running any workspace command for the first time.
+
+When you invoke a workspace command, you will see a prompt like:
+
+```
+This command is provided by workspace: /home/user/my-project
+Do you trust and want to run commands from this workspace? [yN]
+```
+
+- **Accept (y):** The command runs, and your consent is saved so you won't be prompted again (until it expires).
+- **Deny (N or Enter):** The command is not executed. Additionally, the denied workspace's commands are **hidden** from help and autocompletion on subsequent runs, preventing accidental re-prompting.
+
+Consent is stored securely in your system keychain and expires after the duration configured by `USER_CONSENT_LIFE` (default: 30 days). After expiration, you will be prompted again.
+
+> **Note:** Workspace commands appear in `--help` and autocompletion even **before** you consent. This lets you discover what commands are available. Consent is only checked when you actually execute a command.
+
+### Path traversal protection
+
+For security, paths in the `.cdt-packages` file **must not** contain `..` (parent directory traversal). Any line containing `..` is rejected with a warning. This ensures that workspace packages can only reference directories within or below the workspace root.
+
+### Validation
+
+Each path listed in the packages file must point to a directory that contains a valid `manifest.mf` file. Paths that don't meet this requirement are skipped with a warning (visible when logging is enabled).
+
+## Configuration reference
+
+| Config key | Type | Default | Description |
+|---|---|---|---|
+| `ENABLE_WORKSPACE_PACKAGES` | bool | `false` | Enable or disable workspace package discovery |
+| `USER_CONSENT_LIFE` | duration | `720h` (30 days) | How long workspace consent is remembered before re-prompting |
+
+Set these with:
+
+```shell
+cdt config ENABLE_WORKSPACE_PACKAGES true
+cdt config USER_CONSENT_LIFE 720h
+```
+
+## Complete example
+
+Here is a step-by-step example of adding a workspace command to a project.
+
+**1.** Enable the feature (one-time setup):
+
+```shell
+cdt config ENABLE_WORKSPACE_PACKAGES true
+```
+
+**2.** In your project root, create the packages file:
+
+```shell
+echo "tools/hello" > .cdt-packages
+```
+
+**3.** Create the package directory and script:
+
+```shell
+mkdir -p tools/hello
+```
+
+**4.** Create `tools/hello/manifest.mf`:
+
+```json
+{
+  "pkgName": "hello",
+  "version": "1.0.0",
+  "cmds": [
+    {
+      "name": "hello",
+      "type": "executable",
+      "short": "Say hello from workspace",
+      "executable": "{{.PackageDir}}/hello.sh"
+    }
+  ]
+}
+```
+
+**5.** Create `tools/hello/hello.sh`:
+
+```bash
+#!/bin/sh
+echo "Hello from workspace!"
+```
+
+```shell
+chmod +x tools/hello/hello.sh
+```
+
+**6.** Run it (from anywhere inside the project):
+
+```shell
+$ cdt hello
+This command is provided by workspace: /home/user/my-project
+Do you trust and want to run commands from this workspace? [yN] y
+Hello from workspace!
+```
+
+On subsequent runs, the consent prompt is skipped:
+
+```shell
+$ cdt hello
+Hello from workspace!
+```
+
+## Workspace packages vs. dropin packages
+
+| | Workspace packages | Dropin packages |
+|---|---|---|
+| **Scope** | Per-project (based on working directory) | Global (available everywhere) |
+| **Discovery** | Automatic via `.cdt-packages` file | Manual placement in dropin folder |
+| **Version control** | Designed to be checked into git | Typically per-machine |
+| **Consent** | Required before first execution | Not required |
+| **Updates** | Manual (edit files directly) | Manual (or `package install --git`) |
+| **Priority** | Highest (overrides all other sources) | Second highest |
+
+## Troubleshooting
+
+**Commands not showing up:**
+- Verify the feature is enabled: `cdt config ENABLE_WORKSPACE_PACKAGES`
+- Check that you are running `cdt` from inside the workspace (or a subdirectory)
+- Ensure the `.cdt-packages` file name matches your app name (e.g., `.cola-packages` for `cola`)
+- Verify each listed path contains a valid `manifest.mf`
+- Enable logging for detailed diagnostics: `cdt config LOG_ENABLED true && cdt config LOG_LEVEL debug`
+
+**Consent prompt keeps appearing:**
+- The consent has expired. Increase the duration with `cdt config USER_CONSENT_LIFE 2160h` (90 days).
+
+**Command was denied and now it's hidden:**
+- Denial is remembered for the configured `USER_CONSENT_LIFE` duration. Wait for it to expire, or the consent will reset automatically after the configured period.
+
+**Path rejected with "parent directory traversal" warning:**
+- Paths in `.cdt-packages` must not contain `..`. Use paths relative to the packages file location that point downward into the project tree.

--- a/internal/backend/api.go
+++ b/internal/backend/api.go
@@ -65,6 +65,9 @@ type Backend interface {
 	// Return dropin local repsository
 	DropinRepository() repository.PackageRepository
 
+	// Return workspace package sources
+	WorkspaceSources() []*PackageSource
+
 	// Print out the command resolution details
 	Debug()
 }

--- a/internal/backend/default-backend.go
+++ b/internal/backend/default-backend.go
@@ -14,11 +14,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// DefaultBackend supports multiple managed repositories and 1 dropin repository
-// It contains:
-// - 1 dropin local repository - index 0
-// - 1 default managed repository - index 1
-// - n additional managed repository - index 2 ..
+// DefaultBackend supports multiple managed repositories, 1 dropin repository,
+// and 0..n workspace repositories.
+// Source ordering (determines command priority):
+// - workspace sources (0..n, deepest first) - highest priority
+// - 1 dropin local repository
+// - 1 default managed repository
+// - n additional managed repositories - lowest priority
 type DefaultBackend struct {
 	homeDir string
 	sources []*PackageSource
@@ -31,8 +33,6 @@ type DefaultBackend struct {
 	tmpAlias  map[string]string
 }
 
-const DROPIN_REPO_INDEX = 0
-const DEFAULT_REPO_INDEX = 1
 const DEFAULT_REPO_ID = "default"
 const DROPIN_REPO_ID = "dropin"
 
@@ -40,11 +40,17 @@ const RENAME_FILE_NAME = "rename.json"
 
 // Create a new default backend with multiple local repository directories
 // When any of these repositories failed to load, an error is returned.
-func NewDefaultBackend(homeDir string, dropinSource *PackageSource, defaultSource *PackageSource, additionalSources ...*PackageSource) (Backend, error) {
+func NewDefaultBackend(homeDir string, workspaceSources []*PackageSource, dropinSource *PackageSource, defaultSource *PackageSource, additionalSources ...*PackageSource) (Backend, error) {
+	// Build sources slice: workspace (highest priority) -> dropin -> default -> extras (lowest priority)
+	sources := make([]*PackageSource, 0, len(workspaceSources)+2+len(additionalSources))
+	sources = append(sources, workspaceSources...)
+	sources = append(sources, dropinSource, defaultSource)
+	sources = append(sources, additionalSources...)
+
 	backend := &DefaultBackend{
 		// input properties
 		homeDir: homeDir,
-		sources: append([]*PackageSource{dropinSource, defaultSource}, additionalSources...),
+		sources: sources,
 
 		// data need to be reset during reload
 		cmdsCache:      map[string]command.Command{},
@@ -76,7 +82,7 @@ func (backend *DefaultBackend) Reload() error {
 func (backend *DefaultBackend) loadRepos() error {
 	failures := []string{}
 	for _, src := range backend.sources {
-		repo, err := repository.CreateLocalRepository(src.Name, src.RepoDir, nil)
+		repo, err := repository.CreateLocalRepository(src.Name, src.RepoDir, src.CustomRepoIndex)
 		if err != nil {
 			failures = append(failures, err.Error())
 			src.Failure = err
@@ -271,11 +277,21 @@ func (backend *DefaultBackend) FindSystemCommand(name string) (command.Command, 
 }
 
 func (backend DefaultBackend) DefaultRepository() repository.PackageRepository {
-	return backend.sources[DEFAULT_REPO_INDEX].Repo
+	for _, src := range backend.sources {
+		if src.Name == DEFAULT_REPO_ID {
+			return src.Repo
+		}
+	}
+	return nil
 }
 
 func (backend DefaultBackend) DropinRepository() repository.PackageRepository {
-	return backend.sources[DROPIN_REPO_INDEX].Repo
+	for _, src := range backend.sources {
+		if src.Name == DROPIN_REPO_ID {
+			return src.Repo
+		}
+	}
+	return nil
 }
 
 func (backend DefaultBackend) AllPackageSources() []*PackageSource {
@@ -284,12 +300,22 @@ func (backend DefaultBackend) AllPackageSources() []*PackageSource {
 
 func (backend DefaultBackend) ExtraPackageSources() []*PackageSource {
 	extras := []*PackageSource{}
-	for i, src := range backend.sources {
-		if i != DEFAULT_REPO_INDEX && i != DROPIN_REPO_INDEX {
+	for _, src := range backend.sources {
+		if src.Name != DEFAULT_REPO_ID && src.Name != DROPIN_REPO_ID && !strings.HasPrefix(src.Name, WorkspaceSourcePrefix) {
 			extras = append(extras, src)
 		}
 	}
 	return extras
+}
+
+func (backend DefaultBackend) WorkspaceSources() []*PackageSource {
+	sources := []*PackageSource{}
+	for _, src := range backend.sources {
+		if strings.HasPrefix(src.Name, WorkspaceSourcePrefix) {
+			sources = append(sources, src)
+		}
+	}
+	return sources
 }
 
 func (backend DefaultBackend) AllRepositories() []repository.PackageRepository {

--- a/internal/backend/package-source.go
+++ b/internal/backend/package-source.go
@@ -34,6 +34,8 @@ type PackageSource struct {
 	Failure error
 
 	Updater *updater.CmdUpdater
+
+	CustomRepoIndex repository.RepoIndex // nil for standard sources, set for workspace sources
 }
 
 func NewDropinSource(repoDir string) *PackageSource {

--- a/internal/backend/workspace-conflict_test.go
+++ b/internal/backend/workspace-conflict_test.go
@@ -1,0 +1,221 @@
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/criteo/command-launcher/internal/repository"
+	"github.com/stretchr/testify/assert"
+)
+
+// createTestPackageDir creates a package directory with a manifest.mf file
+func createTestPackageDir(t *testing.T, parentDir string, pkgName string, cmds string) string {
+	t.Helper()
+	pkgDir := filepath.Join(parentDir, pkgName)
+	err := os.MkdirAll(pkgDir, 0755)
+	assert.Nil(t, err)
+
+	manifest := `{
+  "pkgName": "` + pkgName + `",
+  "version": "1.0.0",
+  "cmds": [` + cmds + `]
+}`
+	err = os.WriteFile(filepath.Join(pkgDir, "manifest.mf"), []byte(manifest), 0644)
+	assert.Nil(t, err)
+	return pkgDir
+}
+
+func execCmd(name string) string {
+	return `{"name": "` + name + `", "type": "executable", "group": "", "short": "test", "executable": "echo"}`
+}
+
+func groupCmd(name string) string {
+	return `{"name": "` + name + `", "type": "group", "group": "", "short": "test group", "executable": ""}`
+}
+
+func execCmdInGroup(name string, group string) string {
+	return `{"name": "` + name + `", "type": "executable", "group": "` + group + `", "short": "test", "executable": "echo"}`
+}
+
+func makeWorkspaceSource(t *testing.T, dir string, pkgName string, cmds string) *PackageSource {
+	t.Helper()
+	pkgDir := createTestPackageDir(t, dir, pkgName, cmds)
+	repoIndex, err := repository.NewWorkspaceRepoIndex("workspace:"+dir, []string{pkgDir})
+	assert.Nil(t, err)
+	return &PackageSource{
+		Name:            "workspace:" + dir,
+		RepoDir:         dir,
+		SyncPolicy:      SYNC_POLICY_NEVER,
+		IsManaged:       false,
+		CustomRepoIndex: repoIndex,
+	}
+}
+
+func makeDropinSource(t *testing.T, dir string, pkgName string, cmds string) *PackageSource {
+	t.Helper()
+	createTestPackageDir(t, dir, pkgName, cmds)
+	return &PackageSource{
+		Name:       "dropin",
+		RepoDir:    dir,
+		SyncPolicy: SYNC_POLICY_NEVER,
+		IsManaged:  false,
+	}
+}
+
+func makeDefaultSource(t *testing.T, dir string, pkgName string, cmds string) *PackageSource {
+	t.Helper()
+	createTestPackageDir(t, dir, pkgName, cmds)
+	return &PackageSource{
+		Name:       "default",
+		RepoDir:    dir,
+		SyncPolicy: SYNC_POLICY_NEVER,
+		IsManaged:  false,
+	}
+}
+
+func TestWorkspaceOverridesDropin(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+	dropinDir := t.TempDir()
+	defaultDir := t.TempDir()
+
+	workspaceSrc := makeWorkspaceSource(t, workspaceDir, "ws-pkg", execCmd("lint"))
+	dropinSrc := makeDropinSource(t, dropinDir, "dropin-pkg", execCmd("lint"))
+	defaultSrc := makeDefaultSource(t, defaultDir, "default-pkg", execCmd("deploy"))
+
+	be, err := NewDefaultBackend(homeDir, []*PackageSource{workspaceSrc}, dropinSrc, defaultSrc)
+	assert.Nil(t, err)
+
+	// Workspace lint should win the short name
+	cmd, err := be.FindCommand("", "lint")
+	assert.Nil(t, err)
+	assert.Equal(t, "workspace:"+workspaceDir, cmd.RepositoryID())
+
+	// Both commands should be available
+	exeCmds := be.ExecutableCommands()
+	assert.Len(t, exeCmds, 3) // lint (ws), lint (dropin renamed), deploy
+}
+
+func TestWorkspaceOverridesDefault(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+	dropinDir := t.TempDir()
+	defaultDir := t.TempDir()
+
+	// Both define group "build" with executable "run"
+	wsCmds := groupCmd("build") + "," + execCmdInGroup("run", "build")
+	defCmds := groupCmd("build") + "," + execCmdInGroup("run", "build")
+
+	workspaceSrc := makeWorkspaceSource(t, workspaceDir, "ws-build", wsCmds)
+	dropinSrc := makeDropinSource(t, dropinDir, "dropin-pkg", execCmd("other"))
+	defaultSrc := makeDefaultSource(t, defaultDir, "default-build", defCmds)
+
+	be, err := NewDefaultBackend(homeDir, []*PackageSource{workspaceSrc}, dropinSrc, defaultSrc)
+	assert.Nil(t, err)
+
+	// Workspace build group should win
+	cmd, err := be.FindCommand("", "build")
+	assert.Nil(t, err)
+	assert.Equal(t, "workspace:"+workspaceDir, cmd.RepositoryID())
+
+	// Workspace build run should win
+	cmd, err = be.FindCommand("build", "run")
+	assert.Nil(t, err)
+	assert.Equal(t, "workspace:"+workspaceDir, cmd.RepositoryID())
+}
+
+func TestCloserWorkspaceWins(t *testing.T) {
+	homeDir := t.TempDir()
+	deepDir := t.TempDir()
+	shallowDir := t.TempDir()
+	dropinDir := t.TempDir()
+	defaultDir := t.TempDir()
+
+	// Both workspace levels define "deploy" command
+	deepSrc := makeWorkspaceSource(t, deepDir, "deep-pkg", execCmd("deploy"))
+	shallowSrc := makeWorkspaceSource(t, shallowDir, "shallow-pkg", execCmd("deploy"))
+	dropinSrc := makeDropinSource(t, dropinDir, "dropin-pkg", execCmd("other"))
+	defaultSrc := makeDefaultSource(t, defaultDir, "default-pkg", execCmd("yet-another"))
+
+	// Deep source first (closer to cwd)
+	be, err := NewDefaultBackend(homeDir, []*PackageSource{deepSrc, shallowSrc}, dropinSrc, defaultSrc)
+	assert.Nil(t, err)
+
+	// Deeper workspace should win
+	cmd, err := be.FindCommand("", "deploy")
+	assert.Nil(t, err)
+	assert.Equal(t, "workspace:"+deepDir, cmd.RepositoryID())
+}
+
+func TestWorkspaceVsReservedName(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+	dropinDir := t.TempDir()
+	defaultDir := t.TempDir()
+
+	// Workspace defines a group named "config" which is a reserved name
+	workspaceSrc := makeWorkspaceSource(t, workspaceDir, "ws-pkg", groupCmd("config"))
+	dropinSrc := makeDropinSource(t, dropinDir, "dropin-pkg", execCmd("other"))
+	defaultSrc := makeDefaultSource(t, defaultDir, "default-pkg", execCmd("deploy"))
+
+	be, err := NewDefaultBackend(homeDir, []*PackageSource{workspaceSrc}, dropinSrc, defaultSrc)
+	assert.Nil(t, err)
+
+	// The workspace config group should have been renamed (not overriding the reserved name)
+	groupCmds := be.GroupCommands()
+	for _, cmd := range groupCmds {
+		if cmd.RepositoryID() == "workspace:"+workspaceDir {
+			// It should have been renamed to its full name
+			assert.NotEqual(t, "config", cmd.RuntimeName(), "workspace command should not keep reserved name 'config'")
+		}
+	}
+}
+
+func TestNoConflict_DifferentNames(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+	dropinDir := t.TempDir()
+	defaultDir := t.TempDir()
+
+	workspaceSrc := makeWorkspaceSource(t, workspaceDir, "ws-pkg", execCmd("build"))
+	dropinSrc := makeDropinSource(t, dropinDir, "dropin-pkg", execCmd("test"))
+	defaultSrc := makeDefaultSource(t, defaultDir, "default-pkg", execCmd("deploy"))
+
+	be, err := NewDefaultBackend(homeDir, []*PackageSource{workspaceSrc}, dropinSrc, defaultSrc)
+	assert.Nil(t, err)
+
+	// All commands should be accessible by their short names
+	cmd, err := be.FindCommand("", "build")
+	assert.Nil(t, err)
+	assert.Equal(t, "build", cmd.RuntimeName())
+
+	cmd, err = be.FindCommand("", "test")
+	assert.Nil(t, err)
+	assert.Equal(t, "test", cmd.RuntimeName())
+
+	cmd, err = be.FindCommand("", "deploy")
+	assert.Nil(t, err)
+	assert.Equal(t, "deploy", cmd.RuntimeName())
+}
+
+func TestWorkspaceDisabled_NoWorkspaceSources(t *testing.T) {
+	homeDir := t.TempDir()
+	dropinDir := t.TempDir()
+	defaultDir := t.TempDir()
+
+	dropinSrc := makeDropinSource(t, dropinDir, "dropin-pkg", execCmd("lint"))
+	defaultSrc := makeDefaultSource(t, defaultDir, "default-pkg", execCmd("deploy"))
+
+	// No workspace sources (simulating ENABLE_WORKSPACE_PACKAGES=false)
+	be, err := NewDefaultBackend(homeDir, []*PackageSource{}, dropinSrc, defaultSrc)
+	assert.Nil(t, err)
+
+	// Dropin lint should be available
+	cmd, err := be.FindCommand("", "lint")
+	assert.Nil(t, err)
+	assert.Equal(t, "dropin", cmd.RepositoryID())
+
+	// No workspace sources
+	assert.Empty(t, be.WorkspaceSources())
+}

--- a/internal/backend/workspace-source.go
+++ b/internal/backend/workspace-source.go
@@ -1,0 +1,123 @@
+package backend
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/criteo/command-launcher/internal/repository"
+)
+
+const WorkspacePackagesFileName = ".cdt-packages"
+const WorkspaceSourcePrefix = "workspace:"
+
+// DiscoverWorkspaceSources walks up from startDir to the filesystem root,
+// looking for .cdt-packages files. Returns workspace PackageSources ordered
+// deepest-first (closest to startDir has highest priority).
+func DiscoverWorkspaceSources(startDir string) []*PackageSource {
+	sources := []*PackageSource{}
+	dir := startDir
+	checked := ""
+
+	for dir != checked {
+		candidate := filepath.Join(dir, WorkspacePackagesFileName)
+		if _, err := os.Stat(candidate); err == nil {
+			pkgPaths, err := ParseWorkspaceFile(candidate)
+			if err != nil {
+				log.Warnf("workspace: failed to parse %s: %v", candidate, err)
+			} else if len(pkgPaths) > 0 {
+				src, err := NewWorkspaceSource(dir, pkgPaths)
+				if err != nil {
+					log.Warnf("workspace: failed to create source from %s: %v", candidate, err)
+				} else {
+					sources = append(sources, src)
+				}
+			}
+		}
+		checked = dir
+		dir = filepath.Dir(dir)
+	}
+
+	return sources
+}
+
+// ParseWorkspaceFile reads a .cdt-packages file and returns absolute paths
+// to valid package directories. Lines starting with # are comments.
+// Paths containing ".." are rejected for security (packages must be under
+// the workspace directory).
+func ParseWorkspaceFile(filePath string) ([]string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	baseDir := filepath.Dir(filePath)
+	var paths []string
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// reject paths containing ".." for security
+		if containsParentTraversal(line) {
+			log.Warnf("workspace: rejecting path %q in %s: parent directory traversal (..) is not allowed", line, filePath)
+			continue
+		}
+
+		absPath := filepath.Join(baseDir, line)
+
+		// validate that the path exists and contains a manifest.mf
+		manifestPath := filepath.Join(absPath, "manifest.mf")
+		if _, err := os.Stat(manifestPath); err != nil {
+			log.Warnf("workspace: skipping %q in %s: manifest.mf not found at %s", line, filePath, manifestPath)
+			continue
+		}
+
+		paths = append(paths, absPath)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return paths, nil
+}
+
+// containsParentTraversal checks if a path contains ".." components.
+func containsParentTraversal(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+// NewWorkspaceSource creates a PackageSource for a workspace directory
+// containing a .cdt-packages file.
+func NewWorkspaceSource(workspaceDir string, packagePaths []string) (*PackageSource, error) {
+	name := WorkspaceSourcePrefix + workspaceDir
+
+	repoIndex, err := repository.NewWorkspaceRepoIndex(name, packagePaths)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PackageSource{
+		Name:            name,
+		RepoDir:         workspaceDir,
+		RemoteBaseURL:   "",
+		SyncPolicy:      SYNC_POLICY_NEVER,
+		IsManaged:       false,
+		CustomRepoIndex: repoIndex,
+	}, nil
+}

--- a/internal/backend/workspace-source.go
+++ b/internal/backend/workspace-source.go
@@ -53,8 +53,8 @@ func DiscoverWorkspaceSources(startDir string, appName string) []*PackageSource 
 
 // ParseWorkspaceFile reads a .cdt-packages file and returns absolute paths
 // to valid package directories. Lines starting with # are comments.
-// Paths containing ".." are rejected for security (packages must be under
-// the workspace directory).
+// Absolute paths and paths containing ".." are rejected for security
+// (packages must be under the workspace directory).
 func ParseWorkspaceFile(filePath string) ([]string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -74,7 +74,11 @@ func ParseWorkspaceFile(filePath string) ([]string, error) {
 			continue
 		}
 
-		// reject paths containing ".." for security
+		// reject absolute paths and paths containing ".." for security
+		if filepath.IsAbs(line) {
+			log.Warnf("workspace: rejecting path %q in %s: absolute paths are not allowed", line, filePath)
+			continue
+		}
 		if containsParentTraversal(line) {
 			log.Warnf("workspace: rejecting path %q in %s: parent directory traversal (..) is not allowed", line, filePath)
 			continue

--- a/internal/backend/workspace-source.go
+++ b/internal/backend/workspace-source.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,19 +12,25 @@ import (
 	"github.com/criteo/command-launcher/internal/repository"
 )
 
-const WorkspacePackagesFileName = ".cdt-packages"
 const WorkspaceSourcePrefix = "workspace:"
 
+// WorkspacePackagesFileName returns the dot file name for the given app name.
+// For example, app "cdt" -> ".cdt-packages", app "cola" -> ".cola-packages".
+func WorkspacePackagesFileName(appName string) string {
+	return fmt.Sprintf(".%s-packages", appName)
+}
+
 // DiscoverWorkspaceSources walks up from startDir to the filesystem root,
-// looking for .cdt-packages files. Returns workspace PackageSources ordered
+// looking for .<appName>-packages files. Returns workspace PackageSources ordered
 // deepest-first (closest to startDir has highest priority).
-func DiscoverWorkspaceSources(startDir string) []*PackageSource {
+func DiscoverWorkspaceSources(startDir string, appName string) []*PackageSource {
 	sources := []*PackageSource{}
 	dir := startDir
 	checked := ""
+	fileName := WorkspacePackagesFileName(appName)
 
 	for dir != checked {
-		candidate := filepath.Join(dir, WorkspacePackagesFileName)
+		candidate := filepath.Join(dir, fileName)
 		if _, err := os.Stat(candidate); err == nil {
 			pkgPaths, err := ParseWorkspaceFile(candidate)
 			if err != nil {

--- a/internal/backend/workspace-source_test.go
+++ b/internal/backend/workspace-source_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testAppName = "cdt"
+
 func createTestManifest(t *testing.T, dir string, pkgName string) {
 	t.Helper()
 	pkgDir := filepath.Join(dir, pkgName)
@@ -30,9 +32,15 @@ func createTestManifest(t *testing.T, dir string, pkgName string) {
 	assert.Nil(t, err)
 }
 
+func TestWorkspacePackagesFileName(t *testing.T) {
+	assert.Equal(t, ".cdt-packages", WorkspacePackagesFileName("cdt"))
+	assert.Equal(t, ".cola-packages", WorkspacePackagesFileName("cola"))
+	assert.Equal(t, ".cl-packages", WorkspacePackagesFileName("cl"))
+}
+
 func TestDiscoverWorkspaceSources_NoneFound(t *testing.T) {
 	tmpDir := t.TempDir()
-	sources := DiscoverWorkspaceSources(tmpDir)
+	sources := DiscoverWorkspaceSources(tmpDir, testAppName)
 	assert.Empty(t, sources)
 }
 
@@ -48,7 +56,7 @@ func TestDiscoverWorkspaceSources_SingleFile(t *testing.T) {
 	createTestManifest(t, projectDir, "my-tool")
 
 	// Create .cdt-packages
-	err = os.WriteFile(filepath.Join(projectDir, WorkspacePackagesFileName), []byte("my-tool\n"), 0644)
+	err = os.WriteFile(filepath.Join(projectDir, WorkspacePackagesFileName(testAppName)), []byte("my-tool\n"), 0644)
 	assert.Nil(t, err)
 
 	// Start from a subdirectory
@@ -56,7 +64,7 @@ func TestDiscoverWorkspaceSources_SingleFile(t *testing.T) {
 	err = os.MkdirAll(subDir, 0755)
 	assert.Nil(t, err)
 
-	sources := DiscoverWorkspaceSources(subDir)
+	sources := DiscoverWorkspaceSources(subDir, testAppName)
 	assert.Len(t, sources, 1)
 	assert.Equal(t, WorkspaceSourcePrefix+projectDir, sources[0].Name)
 	assert.Equal(t, projectDir, sources[0].RepoDir)
@@ -72,7 +80,7 @@ func TestDiscoverWorkspaceSources_MultipleFiles(t *testing.T) {
 	err := os.MkdirAll(workspaceDir, 0755)
 	assert.Nil(t, err)
 	createTestManifest(t, workspaceDir, "shared-tool")
-	err = os.WriteFile(filepath.Join(workspaceDir, WorkspacePackagesFileName), []byte("shared-tool\n"), 0644)
+	err = os.WriteFile(filepath.Join(workspaceDir, WorkspacePackagesFileName(testAppName)), []byte("shared-tool\n"), 0644)
 	assert.Nil(t, err)
 
 	// Create inner project with a package
@@ -80,7 +88,7 @@ func TestDiscoverWorkspaceSources_MultipleFiles(t *testing.T) {
 	err = os.MkdirAll(projectDir, 0755)
 	assert.Nil(t, err)
 	createTestManifest(t, projectDir, "project-tool")
-	err = os.WriteFile(filepath.Join(projectDir, WorkspacePackagesFileName), []byte("project-tool\n"), 0644)
+	err = os.WriteFile(filepath.Join(projectDir, WorkspacePackagesFileName(testAppName)), []byte("project-tool\n"), 0644)
 	assert.Nil(t, err)
 
 	// Start from project subdirectory
@@ -88,7 +96,7 @@ func TestDiscoverWorkspaceSources_MultipleFiles(t *testing.T) {
 	err = os.MkdirAll(subDir, 0755)
 	assert.Nil(t, err)
 
-	sources := DiscoverWorkspaceSources(subDir)
+	sources := DiscoverWorkspaceSources(subDir, testAppName)
 	assert.Len(t, sources, 2)
 	// Deepest first
 	assert.Equal(t, WorkspaceSourcePrefix+projectDir, sources[0].Name)
@@ -106,7 +114,7 @@ valid-pkg
 
 # Another comment
 `
-	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName)
+	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName(testAppName))
 	err := os.WriteFile(dotFile, []byte(content), 0644)
 	assert.Nil(t, err)
 
@@ -126,7 +134,7 @@ func TestParseWorkspaceFile_RelativePaths(t *testing.T) {
 	createTestManifest(t, filepath.Join(tmpDir, "tools"), "my-tool")
 
 	content := "tools/my-tool\n"
-	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName)
+	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName(testAppName))
 	err = os.WriteFile(dotFile, []byte(content), 0644)
 	assert.Nil(t, err)
 
@@ -140,7 +148,7 @@ func TestParseWorkspaceFile_InvalidPath(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	content := "nonexistent-package\n"
-	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName)
+	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName(testAppName))
 	err := os.WriteFile(dotFile, []byte(content), 0644)
 	assert.Nil(t, err)
 
@@ -164,7 +172,7 @@ func TestParseWorkspaceFile_RejectParentTraversal(t *testing.T) {
 	content := `../outside/evil-pkg
 tools/../../outside/evil-pkg
 `
-	dotFile := filepath.Join(workspaceDir, WorkspacePackagesFileName)
+	dotFile := filepath.Join(workspaceDir, WorkspacePackagesFileName(testAppName))
 	err = os.WriteFile(dotFile, []byte(content), 0644)
 	assert.Nil(t, err)
 
@@ -186,7 +194,7 @@ func TestParseWorkspaceFile_AllowDotPaths(t *testing.T) {
 	content := `./tools/my-tool
 .hidden/hidden-tool
 `
-	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName)
+	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName(testAppName))
 	err := os.WriteFile(dotFile, []byte(content), 0644)
 	assert.Nil(t, err)
 

--- a/internal/backend/workspace-source_test.go
+++ b/internal/backend/workspace-source_test.go
@@ -181,6 +181,22 @@ tools/../../outside/evil-pkg
 	assert.Empty(t, paths, "paths with .. should be rejected")
 }
 
+func TestParseWorkspaceFile_RejectAbsolutePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a package at an absolute path
+	createTestManifest(t, tmpDir, "abs-pkg")
+
+	content := filepath.Join(tmpDir, "abs-pkg") + "\n"
+	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName(testAppName))
+	err := os.WriteFile(dotFile, []byte(content), 0644)
+	assert.Nil(t, err)
+
+	paths, err := ParseWorkspaceFile(dotFile)
+	assert.Nil(t, err)
+	assert.Empty(t, paths, "absolute paths should be rejected")
+}
+
 func TestParseWorkspaceFile_AllowDotPaths(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/backend/workspace-source_test.go
+++ b/internal/backend/workspace-source_test.go
@@ -1,0 +1,206 @@
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestManifest(t *testing.T, dir string, pkgName string) {
+	t.Helper()
+	pkgDir := filepath.Join(dir, pkgName)
+	err := os.MkdirAll(pkgDir, 0755)
+	assert.Nil(t, err)
+	manifest := []byte(`{
+  "pkgName": "` + pkgName + `",
+  "version": "1.0.0",
+  "cmds": [
+    {
+      "name": "` + pkgName + `-cmd",
+      "type": "executable",
+      "group": "",
+      "short": "test command",
+      "executable": "echo"
+    }
+  ]
+}`)
+	err = os.WriteFile(filepath.Join(pkgDir, "manifest.mf"), manifest, 0644)
+	assert.Nil(t, err)
+}
+
+func TestDiscoverWorkspaceSources_NoneFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	sources := DiscoverWorkspaceSources(tmpDir)
+	assert.Empty(t, sources)
+}
+
+func TestDiscoverWorkspaceSources_SingleFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create project structure
+	projectDir := filepath.Join(tmpDir, "project")
+	err := os.MkdirAll(projectDir, 0755)
+	assert.Nil(t, err)
+
+	// Create a package
+	createTestManifest(t, projectDir, "my-tool")
+
+	// Create .cdt-packages
+	err = os.WriteFile(filepath.Join(projectDir, WorkspacePackagesFileName), []byte("my-tool\n"), 0644)
+	assert.Nil(t, err)
+
+	// Start from a subdirectory
+	subDir := filepath.Join(projectDir, "src", "deep")
+	err = os.MkdirAll(subDir, 0755)
+	assert.Nil(t, err)
+
+	sources := DiscoverWorkspaceSources(subDir)
+	assert.Len(t, sources, 1)
+	assert.Equal(t, WorkspaceSourcePrefix+projectDir, sources[0].Name)
+	assert.Equal(t, projectDir, sources[0].RepoDir)
+	assert.False(t, sources[0].IsManaged)
+	assert.Equal(t, SYNC_POLICY_NEVER, sources[0].SyncPolicy)
+}
+
+func TestDiscoverWorkspaceSources_MultipleFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create outer workspace with a package
+	workspaceDir := filepath.Join(tmpDir, "workspace")
+	err := os.MkdirAll(workspaceDir, 0755)
+	assert.Nil(t, err)
+	createTestManifest(t, workspaceDir, "shared-tool")
+	err = os.WriteFile(filepath.Join(workspaceDir, WorkspacePackagesFileName), []byte("shared-tool\n"), 0644)
+	assert.Nil(t, err)
+
+	// Create inner project with a package
+	projectDir := filepath.Join(workspaceDir, "my-project")
+	err = os.MkdirAll(projectDir, 0755)
+	assert.Nil(t, err)
+	createTestManifest(t, projectDir, "project-tool")
+	err = os.WriteFile(filepath.Join(projectDir, WorkspacePackagesFileName), []byte("project-tool\n"), 0644)
+	assert.Nil(t, err)
+
+	// Start from project subdirectory
+	subDir := filepath.Join(projectDir, "src")
+	err = os.MkdirAll(subDir, 0755)
+	assert.Nil(t, err)
+
+	sources := DiscoverWorkspaceSources(subDir)
+	assert.Len(t, sources, 2)
+	// Deepest first
+	assert.Equal(t, WorkspaceSourcePrefix+projectDir, sources[0].Name)
+	assert.Equal(t, WorkspaceSourcePrefix+workspaceDir, sources[1].Name)
+}
+
+func TestParseWorkspaceFile_CommentsAndBlanks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	createTestManifest(t, tmpDir, "valid-pkg")
+
+	content := `# This is a comment
+
+valid-pkg
+
+# Another comment
+`
+	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName)
+	err := os.WriteFile(dotFile, []byte(content), 0644)
+	assert.Nil(t, err)
+
+	paths, err := ParseWorkspaceFile(dotFile)
+	assert.Nil(t, err)
+	assert.Len(t, paths, 1)
+	assert.Equal(t, filepath.Join(tmpDir, "valid-pkg"), paths[0])
+}
+
+func TestParseWorkspaceFile_RelativePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create package in a nested directory
+	toolsDir := filepath.Join(tmpDir, "tools", "my-tool")
+	err := os.MkdirAll(toolsDir, 0755)
+	assert.Nil(t, err)
+	createTestManifest(t, filepath.Join(tmpDir, "tools"), "my-tool")
+
+	content := "tools/my-tool\n"
+	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName)
+	err = os.WriteFile(dotFile, []byte(content), 0644)
+	assert.Nil(t, err)
+
+	paths, err := ParseWorkspaceFile(dotFile)
+	assert.Nil(t, err)
+	assert.Len(t, paths, 1)
+	assert.Equal(t, filepath.Join(tmpDir, "tools", "my-tool"), paths[0])
+}
+
+func TestParseWorkspaceFile_InvalidPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	content := "nonexistent-package\n"
+	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName)
+	err := os.WriteFile(dotFile, []byte(content), 0644)
+	assert.Nil(t, err)
+
+	paths, err := ParseWorkspaceFile(dotFile)
+	assert.Nil(t, err)
+	assert.Empty(t, paths)
+}
+
+func TestParseWorkspaceFile_RejectParentTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a package outside the workspace
+	outsideDir := filepath.Join(tmpDir, "outside")
+	createTestManifest(t, outsideDir, "evil-pkg")
+
+	// Create workspace inside
+	workspaceDir := filepath.Join(tmpDir, "workspace")
+	err := os.MkdirAll(workspaceDir, 0755)
+	assert.Nil(t, err)
+
+	content := `../outside/evil-pkg
+tools/../../outside/evil-pkg
+`
+	dotFile := filepath.Join(workspaceDir, WorkspacePackagesFileName)
+	err = os.WriteFile(dotFile, []byte(content), 0644)
+	assert.Nil(t, err)
+
+	paths, err := ParseWorkspaceFile(dotFile)
+	assert.Nil(t, err)
+	assert.Empty(t, paths, "paths with .. should be rejected")
+}
+
+func TestParseWorkspaceFile_AllowDotPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create package with dot prefix path
+	createTestManifest(t, filepath.Join(tmpDir, "tools"), "my-tool")
+
+	// Create package in a hidden directory
+	hiddenDir := filepath.Join(tmpDir, ".hidden")
+	createTestManifest(t, hiddenDir, "hidden-tool")
+
+	content := `./tools/my-tool
+.hidden/hidden-tool
+`
+	dotFile := filepath.Join(tmpDir, WorkspacePackagesFileName)
+	err := os.WriteFile(dotFile, []byte(content), 0644)
+	assert.Nil(t, err)
+
+	paths, err := ParseWorkspaceFile(dotFile)
+	assert.Nil(t, err)
+	assert.Len(t, paths, 2)
+}
+
+func TestContainsParentTraversal(t *testing.T) {
+	assert.True(t, containsParentTraversal("../foo"))
+	assert.True(t, containsParentTraversal("foo/../../bar"))
+	assert.True(t, containsParentTraversal(".."))
+	assert.False(t, containsParentTraversal("./foo"))
+	assert.False(t, containsParentTraversal("foo/bar"))
+	assert.False(t, containsParentTraversal(".hidden/pkg"))
+	assert.False(t, containsParentTraversal("tools/my-tool"))
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -112,6 +112,8 @@ func setDefaultConfig() {
 	viper.SetDefault(VERIFY_PACKAGE_CHECKSUM_KEY, false)
 	viper.SetDefault(VERIFY_PACKAGE_SIGNATURE_KEY, false)
 
+	viper.SetDefault(ENABLE_WORKSPACE_PACKAGES_KEY, false)
+
 	viper.SetDefault(EXTRA_REMOTES_KEY, []map[string]string{})
 	viper.SetDefault(ENABLE_PACKAGE_SETUP_HOOK_KEY, false)
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -38,6 +38,7 @@ const (
 	EXTRA_REMOTE_SYNC_POLICY_KEY         = "SYNC_POLICY"
 	ENABLE_PACKAGE_SETUP_HOOK_KEY        = "ENABLE_PACKAGE_SETUP_HOOK"
 	GROUP_HELP_BY_REGISTRY_KEY           = "GROUP_HELP_BY_REGISTRY"
+	ENABLE_WORKSPACE_PACKAGES_KEY        = "ENABLE_WORKSPACE_PACKAGES"
 
 	// internal commands are the commands with start partition number > INTERNAL_START_PARTITION
 	INTERNAL_COMMAND_ENABLED_KEY = "INTERNAL_COMMAND_ENABLED"
@@ -79,6 +80,7 @@ func init() {
 		SYSTEM_PACKAGE_PUBLIC_KEY_FILE_KEY,
 		ENABLE_PACKAGE_SETUP_HOOK_KEY,
 		GROUP_HELP_BY_REGISTRY_KEY,
+		ENABLE_WORKSPACE_PACKAGES_KEY,
 	)
 }
 
@@ -136,6 +138,8 @@ func SetSettingValue(key string, value string) error {
 	case ENABLE_PACKAGE_SETUP_HOOK_KEY:
 		return setBooleanConfig(upperKey, value)
 	case GROUP_HELP_BY_REGISTRY_KEY:
+		return setBooleanConfig(upperKey, value)
+	case ENABLE_WORKSPACE_PACKAGES_KEY:
 		return setBooleanConfig(upperKey, value)
 	}
 

--- a/internal/frontend/default-frontend.go
+++ b/internal/frontend/default-frontend.go
@@ -313,7 +313,7 @@ func (self *defaultFrontend) getExecutableCommand(group, name string) (command.C
 }
 
 // execute a cdt command
-func (self *defaultFrontend) executeCommand(group, name string, args []string, initialEnvCtx []string, consent []string) (int, error) {
+func (self *defaultFrontend) executeCommand(group, name string, args []string, initialEnvCtx []string, userConsent []string) (int, error) {
 	iCmd, err := self.getExecutableCommand(group, name)
 	if err != nil {
 		return 1, err
@@ -322,7 +322,15 @@ func (self *defaultFrontend) executeCommand(group, name string, args []string, i
 		return 1, errors.New(EXECUTABLE_NOT_DEFINED)
 	}
 
-	envCtx := self.getCmdEnvContext(iCmd, initialEnvCtx, consent)
+	// Check workspace consent before executing workspace commands
+	if strings.HasPrefix(iCmd.RepositoryID(), backend.WorkspaceSourcePrefix) {
+		workspaceDir := strings.TrimPrefix(iCmd.RepositoryID(), backend.WorkspaceSourcePrefix)
+		if !consent.CheckWorkspaceConsent(workspaceDir) && !consent.RequestWorkspaceConsent(workspaceDir) {
+			return 1, fmt.Errorf("workspace command execution denied: user did not consent to workspace %s", workspaceDir)
+		}
+	}
+
+	envCtx := self.getCmdEnvContext(iCmd, initialEnvCtx, userConsent)
 
 	exitCode, err := iCmd.Execute(envCtx, args...)
 	if err != nil {

--- a/internal/repository/workspace-repo-index.go
+++ b/internal/repository/workspace-repo-index.go
@@ -1,0 +1,82 @@
+package repository
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/criteo/command-launcher/internal/command"
+	"github.com/criteo/command-launcher/internal/pkg"
+)
+
+// workspaceRepoIndex implements RepoIndex for workspace packages.
+// Instead of scanning a directory for subdirectories with manifest.mf,
+// it loads packages from a pre-supplied list of absolute package directory paths.
+type workspaceRepoIndex struct {
+	defaultRepoIndex
+	packagePaths []string // absolute paths to package folders
+}
+
+func NewWorkspaceRepoIndex(id string, packagePaths []string) (RepoIndex, error) {
+	base, err := newDefaultRepoIndex(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workspaceRepoIndex{
+		defaultRepoIndex: *base.(*defaultRepoIndex),
+		packagePaths:     packagePaths,
+	}, nil
+}
+
+// Load ignores the repoDir parameter and loads packages from the pre-supplied paths.
+func (idx *workspaceRepoIndex) Load(repoDir string) error {
+	for _, pkgPath := range idx.packagePaths {
+		manifestPath := filepath.Join(pkgPath, "manifest.mf")
+		manifestFile, err := os.Open(manifestPath)
+		if err != nil {
+			log.Warnf("workspace package: cannot open manifest at %s: %v", manifestPath, err)
+			continue
+		}
+
+		manifest, err := pkg.ReadManifest(manifestFile)
+		manifestFile.Close()
+		if err != nil {
+			log.Warnf("workspace package: cannot parse manifest at %s: %v", manifestPath, err)
+			continue
+		}
+
+		idx.packages[manifest.Name()] = manifest
+		idx.packageDirs[manifest.Name()] = pkgPath
+	}
+
+	idx.extractCmds("")
+	return nil
+}
+
+// Add returns an error because workspace packages are read-only.
+func (idx *workspaceRepoIndex) Add(p command.PackageManifest, repoDir string, pkgDirName string) error {
+	return fmt.Errorf("workspace packages are read-only")
+}
+
+// Remove returns an error because workspace packages are read-only.
+func (idx *workspaceRepoIndex) Remove(pkgName string, repoDir string) error {
+	return fmt.Errorf("workspace packages are read-only")
+}
+
+// Update returns an error because workspace packages are read-only.
+func (idx *workspaceRepoIndex) Update(p command.PackageManifest, repoDir string, pkgDirName string) error {
+	return fmt.Errorf("workspace packages are read-only")
+}
+
+// IsPackageUpdatePaused always returns false for workspace packages.
+func (idx *workspaceRepoIndex) IsPackageUpdatePaused(name string) (bool, error) {
+	return false, nil
+}
+
+// PausePackageUpdate returns an error because workspace packages are read-only.
+func (idx *workspaceRepoIndex) PausePackageUpdate(name string) error {
+	return fmt.Errorf("workspace packages are read-only")
+}

--- a/internal/repository/workspace-repo-index_test.go
+++ b/internal/repository/workspace-repo-index_test.go
@@ -1,0 +1,146 @@
+package repository
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestPkgDir(t *testing.T, parentDir string, pkgName string, cmdName string, cmdType string) string {
+	t.Helper()
+	pkgDir := filepath.Join(parentDir, pkgName)
+	err := os.MkdirAll(pkgDir, 0755)
+	assert.Nil(t, err)
+
+	manifest := []byte(`{
+  "pkgName": "` + pkgName + `",
+  "version": "1.0.0",
+  "cmds": [
+    {
+      "name": "` + cmdName + `",
+      "type": "` + cmdType + `",
+      "group": "",
+      "short": "test command",
+      "executable": "echo"
+    }
+  ]
+}`)
+	err = os.WriteFile(filepath.Join(pkgDir, "manifest.mf"), manifest, 0644)
+	assert.Nil(t, err)
+	return pkgDir
+}
+
+func TestWorkspaceRepoIndex_Load(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkg1Dir := createTestPkgDir(t, tmpDir, "pkg1", "cmd1", "executable")
+	pkg2Dir := createTestPkgDir(t, filepath.Join(tmpDir, "tools"), "pkg2", "cmd2", "executable")
+
+	idx, err := NewWorkspaceRepoIndex("workspace:test", []string{pkg1Dir, pkg2Dir})
+	assert.Nil(t, err)
+
+	err = idx.Load("")
+	assert.Nil(t, err)
+
+	pkgs := idx.AllPackages()
+	assert.Len(t, pkgs, 2)
+
+	cmds := idx.ExecutableCommands()
+	assert.Len(t, cmds, 2)
+
+	// Verify we can find both packages
+	p1, err := idx.Package("pkg1")
+	assert.Nil(t, err)
+	assert.NotNil(t, p1)
+
+	p2, err := idx.Package("pkg2")
+	assert.Nil(t, err)
+	assert.NotNil(t, p2)
+}
+
+func TestWorkspaceRepoIndex_ReadOnly(t *testing.T) {
+	idx, err := NewWorkspaceRepoIndex("workspace:test", []string{})
+	assert.Nil(t, err)
+
+	err = idx.Add(nil, "", "")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "read-only")
+
+	err = idx.Remove("foo", "")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "read-only")
+
+	err = idx.Update(nil, "", "")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "read-only")
+
+	err = idx.PausePackageUpdate("foo")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "read-only")
+}
+
+func TestWorkspaceRepoIndex_ScatteredPaths(t *testing.T) {
+	// Create packages in completely separate temp directories
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	pkg1Dir := createTestPkgDir(t, dir1, "scattered-a", "cmd-a", "executable")
+	pkg2Dir := createTestPkgDir(t, dir2, "scattered-b", "cmd-b", "executable")
+
+	idx, err := NewWorkspaceRepoIndex("workspace:scattered", []string{pkg1Dir, pkg2Dir})
+	assert.Nil(t, err)
+
+	err = idx.Load("")
+	assert.Nil(t, err)
+
+	pkgs := idx.AllPackages()
+	assert.Len(t, pkgs, 2)
+
+	cmds := idx.ExecutableCommands()
+	assert.Len(t, cmds, 2)
+
+	// Verify PackageDir is set correctly for each command
+	for _, cmd := range cmds {
+		if cmd.Name() == "cmd-a" {
+			assert.Equal(t, pkg1Dir, cmd.PackageDir())
+		} else if cmd.Name() == "cmd-b" {
+			assert.Equal(t, pkg2Dir, cmd.PackageDir())
+		}
+	}
+}
+
+func TestWorkspaceRepoIndex_InvalidManifest(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a directory with an invalid manifest
+	badDir := filepath.Join(tmpDir, "bad-pkg")
+	err := os.MkdirAll(badDir, 0755)
+	assert.Nil(t, err)
+	err = os.WriteFile(filepath.Join(badDir, "manifest.mf"), []byte("not valid json"), 0644)
+	assert.Nil(t, err)
+
+	// Create a valid package too
+	goodDir := createTestPkgDir(t, tmpDir, "good-pkg", "good-cmd", "executable")
+
+	idx, err := NewWorkspaceRepoIndex("workspace:test", []string{badDir, goodDir})
+	assert.Nil(t, err)
+
+	err = idx.Load("")
+	assert.Nil(t, err)
+
+	// Should have loaded only the good package
+	pkgs := idx.AllPackages()
+	assert.Len(t, pkgs, 1)
+	assert.Equal(t, "good-pkg", pkgs[0].Name())
+}
+
+func TestWorkspaceRepoIndex_IsPackageUpdatePaused(t *testing.T) {
+	idx, err := NewWorkspaceRepoIndex("workspace:test", []string{})
+	assert.Nil(t, err)
+
+	paused, err := idx.IsPackageUpdatePaused("any")
+	assert.Nil(t, err)
+	assert.False(t, paused)
+}

--- a/test/integration/test-workspace.sh
+++ b/test/integration/test-workspace.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+
+# required environment variable
+# CL_PATH
+# CL_HOME
+# OUTPUT_DIR
+
+SCRIPT_DIR=${1:-$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )}
+
+###
+# Setup workspace project structure
+###
+WORKSPACE_DIR=$OUTPUT_DIR/workspace-project
+mkdir -p $WORKSPACE_DIR/src
+cp -R $SCRIPT_DIR/../packages-src/workspace-tool $WORKSPACE_DIR/workspace-tool
+
+# Create .cl-packages file (binary name is "cl" in integration tests)
+echo "workspace-tool" > $WORKSPACE_DIR/.cl-packages
+
+# Enable workspace packages with short consent life for testing
+$CL_PATH config ENABLE_WORKSPACE_PACKAGES true
+$CL_PATH config user_consent_life 3s
+
+# Wait for any stale consent from previous test runs to expire
+sleep 4
+
+###
+# Test: workspace command appears in help (loaded without consent)
+###
+echo "> test workspace command appears in help"
+RESULT=$(cd $WORKSPACE_DIR/src && $CL_PATH --help)
+echo "$RESULT" | grep -q "ws-hello"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - workspace command ws-hello should appear in help"
+  exit 1
+fi
+
+###
+# Test: workspace command appears in autocompletion
+###
+echo "> test workspace command appears in autocompletion"
+RESULT=$(cd $WORKSPACE_DIR/src && $CL_PATH __complete ws-hel)
+echo "$RESULT" | grep -q "ws-hello"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - workspace command ws-hello should appear in autocompletion"
+  exit 1
+fi
+
+###
+# Test: workspace consent - user accepts
+###
+echo "> test workspace consent - user accepts"
+RESULT=$(cd $WORKSPACE_DIR/src && echo 'y' | $CL_PATH ws-hello 2>&1)
+echo "$RESULT"
+echo "$RESULT" | grep -q "This command is provided by workspace"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should show workspace consent prompt"
+  exit 1
+fi
+
+echo "$RESULT" | grep -q "hello from workspace"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should execute workspace command when accepted"
+  exit 1
+fi
+
+###
+# Test: workspace consent remembered - no prompt on second run
+###
+echo "> test workspace consent remembered - no prompt on second run"
+RESULT=$(cd $WORKSPACE_DIR/src && $CL_PATH ws-hello 2>&1)
+echo "$RESULT"
+echo "$RESULT" | grep -q "Do you trust"
+if [ $? -eq 0 ]; then
+  echo "KO - should NOT prompt for consent again"
+  exit 1
+else
+  echo "OK"
+fi
+
+echo "$RESULT" | grep -q "hello from workspace"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should execute workspace command without re-prompting"
+  exit 1
+fi
+
+###
+# Test: workspace consent - user refuses (use a separate workspace)
+# Wait for any stale consent/denial from previous test runs to expire
+###
+echo "> test workspace consent - user refuses"
+DENY_WORKSPACE_DIR=$OUTPUT_DIR/deny-workspace
+mkdir -p $DENY_WORKSPACE_DIR/src
+cp -R $SCRIPT_DIR/../packages-src/workspace-tool $DENY_WORKSPACE_DIR/workspace-tool
+echo "workspace-tool" > $DENY_WORKSPACE_DIR/.cl-packages
+
+sleep 4
+
+RESULT=$(cd $DENY_WORKSPACE_DIR/src && echo 'n' | $CL_PATH ws-hello 2>&1)
+echo "$RESULT"
+echo "$RESULT" | grep -q "This command is provided by workspace"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should show workspace consent prompt"
+  exit 1
+fi
+
+echo "$RESULT" | grep -q "execution denied"
+if [ $? -eq 0 ]; then
+  echo "OK"
+else
+  echo "KO - should show execution denied message"
+  exit 1
+fi
+
+echo "$RESULT" | grep -q "hello from workspace"
+if [ $? -eq 0 ]; then
+  echo "KO - should NOT execute workspace command when refused"
+  exit 1
+else
+  echo "OK"
+fi
+
+###
+# Test: after denial, workspace command no longer appears
+###
+echo "> test denied workspace command no longer appears"
+RESULT=$(cd $DENY_WORKSPACE_DIR/src && $CL_PATH --help)
+echo "$RESULT" | grep -q "ws-hello"
+if [ $? -eq 0 ]; then
+  echo "KO - workspace command should NOT appear after denial"
+  exit 1
+else
+  echo "OK"
+fi
+
+###
+# Test: workspace command not visible when feature disabled
+###
+echo "> test workspace command not visible when feature disabled"
+$CL_PATH config ENABLE_WORKSPACE_PACKAGES false
+RESULT=$(cd $WORKSPACE_DIR/src && $CL_PATH --help)
+echo "$RESULT" | grep -q "ws-hello"
+if [ $? -eq 0 ]; then
+  echo "KO - workspace command should NOT appear when feature disabled"
+  exit 1
+else
+  echo "OK"
+fi
+
+###
+# Test: workspace command not visible outside workspace
+###
+echo "> test workspace command not visible outside workspace"
+$CL_PATH config ENABLE_WORKSPACE_PACKAGES true
+RESULT=$(cd $OUTPUT_DIR && $CL_PATH --help)
+echo "$RESULT" | grep -q "ws-hello"
+if [ $? -eq 0 ]; then
+  echo "KO - workspace command should NOT appear outside workspace"
+  exit 1
+else
+  echo "OK"
+fi
+
+###
+# Test: .cl-packages with parent traversal rejected
+###
+echo "> test parent traversal rejected"
+SAFE_DIR=$OUTPUT_DIR/safe-project
+mkdir -p $SAFE_DIR
+echo "../workspace-project/workspace-tool" > $SAFE_DIR/.cl-packages
+RESULT=$(cd $SAFE_DIR && $CL_PATH --help)
+echo "$RESULT" | grep -q "ws-hello"
+if [ $? -eq 0 ]; then
+  echo "KO - parent traversal paths should be rejected"
+  exit 1
+else
+  echo "OK"
+fi

--- a/test/packages-src/workspace-tool/hello.bat
+++ b/test/packages-src/workspace-tool/hello.bat
@@ -1,0 +1,2 @@
+@ECHO OFF
+echo hello from workspace!

--- a/test/packages-src/workspace-tool/hello.sh
+++ b/test/packages-src/workspace-tool/hello.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hello from workspace!"

--- a/test/packages-src/workspace-tool/manifest.mf
+++ b/test/packages-src/workspace-tool/manifest.mf
@@ -6,7 +6,7 @@
       "name": "ws-hello",
       "type": "executable",
       "short": "a workspace hello command",
-      "executable": "{{.PackageDir}}/hello.sh"
+      "executable": "{{.PackageDir}}/hello.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}"
     }
   ]
 }

--- a/test/packages-src/workspace-tool/manifest.mf
+++ b/test/packages-src/workspace-tool/manifest.mf
@@ -1,0 +1,12 @@
+{
+  "pkgName": "workspace-tool",
+  "version": "1.0.0",
+  "cmds": [
+    {
+      "name": "ws-hello",
+      "type": "executable",
+      "short": "a workspace hello command",
+      "executable": "{{.PackageDir}}/hello.sh"
+    }
+  ]
+}


### PR DESCRIPTION
Today command launcher load packages in the following order:
1. dropin folder
2. default repository
3. extra registries
All these package repositories are centralized in a single folder (by default $HOME/.[BINARY NAME], ex. $HOME/.cola) defined in the configuration.   

This doesn't answer the local development scenario: commands that are useful for a particular workspace, for example, script to build, test, run the project. These commands usually don't make sense at all if not being executed under the workspace. Uploading them to a registry for sharing is over kill. 

In this PR, we introduce a concept of workspace package: in the descendant of the workspace, we can define a command launcher package as usual, and a `.[BINARY_NAME]-packages` file at the root of the workspace can be used to point to the relative path to the commander launcher package.
```
# relative path (relative to this file, .. is not allowed) to the workspace package
tools/dev-cli
```
In the above example, the `.cola-package` tell the cola to load the package in the folder [PATH of the dotfile]/tools/dev-cli.

Command Launcher will search all parent folder to merge all workspace package files.

**Command Priority and Conflicts**
If two commands use the same name, the following priority rules apply
1. workspace package has highest priorty
2. then package in dropin repo
3. then pakcage in default repo
4. then extra repo
For workspace packages, the closest to the current folder get highest priorty.

The low priority command will be named with its full name: name@group@repo@registry. For example:
```
build@ci@ci@dropin
```
It means a command `cola ci build` define in the `ci` package in `dropin` repository.

**Use Case**
Project can define their project specific command directly in their own repository, and once we are in the project folder, we can execute these command using command launcher automatically