### PR TITLE
Support named parameters in the build script

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,9 +58,8 @@ jobs:
         GOARCH: ${{matrix.arch}}
         CGO_ENABLED: ${{matrix.cgo}}
       run: |
-        go build -o build/cdt_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}} -ldflags='-X main.version=${{github.ref_name}} -X main.buildNum=${{github.run_number}} -X main.appName=cdt'
-
-        go build -o build/cola_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}} -ldflags="-X main.version=${{github.ref_name}} -X main.buildNum=${{github.run_number}} -X main.appName=cola -X 'main.appLongName=Command Launcher'"
+        ./build.sh -v ${{github.ref_name}} -b ${{github.run_number}} -n cdt -l "Criteo Dev Toolkit" -o build/cdt_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}}
+        ./build.sh -v ${{github.ref_name}} -b ${{github.run_number}} -n cola -l "Command Launcher" -o build/cola_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}}
 
     - name: Test & Benchmark
       run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,6 +57,7 @@ jobs:
       env:
         GOARCH: ${{matrix.arch}}
         CGO_ENABLED: ${{matrix.cgo}}
+      shell: bash
       run: |
         ./build.sh -v ${{github.ref_name}} -b ${{github.run_number}} -n cdt -l "Criteo Dev Toolkit" -o build/cdt_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}}
         ./build.sh -v ${{github.ref_name}} -b ${{github.run_number}} -n cola -l "Command Launcher" -o build/cola_${{steps.vars.outputs.os}}_${{matrix.arch}}_${{steps.vars.outputs.sha_short}}

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ You can build the command launcher with your prefered name (in the example: `Cri
 go build -o cdt -ldflags='-X main.version=dev -X main.appName=cdt -X "main.appLongName=Criteo Dev Toolkit"' main.go
 ```
 
-Or simply call the `build.sh` scripts
-```
-./build.sh [version] [app name] [app long name]
+Or using the `build.sh` script
+```shell
+./build.sh -v VERSION -n APP_NAME -l APP_LONG_NAME
 ```
 
 ### Run tests

--- a/build.sh
+++ b/build.sh
@@ -109,6 +109,11 @@ while [ $# -gt 0 ]; do
             show_usage
             exit 0
             ;;
+        --resign)
+            # Legacy compat: accept --resign without short flag in positional mode
+            RESIGN=1
+            shift 1
+            ;;
         -*)
             echo "Error: Unknown option $1" >&2
             show_usage

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,153 @@
 #!/usr/bin/env sh
 
-DEFAULT_VERSION=$(git rev-parse --abbrev-ref HEAD)-dev
+DEBUG=0
 
-VERSION=${1:-$DEFAULT_VERSION}
-APP_NAME=${2:-cdt}
-APP_LONG_NAME=${3:-Criteo Dev Toolkit}
+# Default values
+DEFAULT_APP_NAME="cdt"
+DEFAULT_APP_LONG_NAME="Criteo Dev Toolkit"
 
-go build -o $APP_NAME -ldflags="-X main.version=$VERSION -X main.buildNum=$(date +'%Y%m%d-%H%M%S') -X main.appName=$APP_NAME -X 'main.appLongName=$APP_LONG_NAME'"
+default_version() {
+    echo "$(git rev-parse --abbrev-ref HEAD)-dev"
+}
+
+default_build_number() {
+    date +'%Y%m%d-%H%M%S'
+}
+
+debug() {
+    if [ $DEBUG -eq 1 ]; then
+        echo "$1"
+    fi
+}
+
+# Function to show usage
+show_usage() {
+    program=$(basename "$0")
+    cat <<EOF
+Usage:
+    $program [OPTIONS]
+    OR
+    $program VERSION APP_NAME APP_LONG_NAME
+
+Options:
+    -v, --version VERSION      Set version
+    -n, --name NAME            Set app name
+    -l, --long-name LONG_NAME  Set app long name
+    -o, --output OUTPUT        Set output file name (default: APP_NAME)
+    -b, --build-number NUMBER  Set build number (default: timestamp)
+    -d, --debug                Enable debug output
+    -h, --help                 Show this help message
+
+Examples:
+    $program                                   # Use all defaults
+    $program 1.0.0                             # Set version only (legacy)
+    $program 1.0.0 myapp 'My App'              # Set all three (legacy)
+    $program -v 1.0.0                          # Set version only
+    $program -n myapp                          # Set app name only
+    $program -l 'My App'                       # Set app long name only
+    $program -v 1.0.0 -n myapp -l 'My App'    # Set all three
+    $program -b 42                             # Set build number
+EOF
+}
+
+validate_argument() {
+    if [ -z "$2" ] || [ "${2#-}" = "$2" ]; then
+        return 0
+    else
+        echo "Error: $1 requires a value" >&2
+        exit 1
+    fi
+}
+
+# Parse options
+VERSION=
+APP_NAME=
+APP_LONG_NAME=
+OUTPUT=
+BUILD_NUMBER=
+POSITIONAL_COUNT=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -v|--version)
+            validate_argument "$1" "$2"
+            VERSION="$2"
+            shift 2
+            ;;
+        -n|--name)
+            validate_argument "$1" "$2"
+            APP_NAME="$2"
+            shift 2
+            ;;
+        -l|--long-name)
+            validate_argument "$1" "$2"
+            APP_LONG_NAME="$2"
+            shift 2
+            ;;
+        -o|--output)
+            validate_argument "$1" "$2"
+            OUTPUT="$2"
+            shift 2
+            ;;
+        -b|--build-number)
+            validate_argument "$1" "$2"
+            BUILD_NUMBER="$2"
+            shift 2
+            ;;
+        -d|--debug)
+            DEBUG=1
+            shift 1
+            ;;
+        -h|--help)
+            show_usage
+            exit 0
+            ;;
+        -*)
+            echo "Error: Unknown option $1" >&2
+            show_usage
+            exit 1
+            ;;
+        *)
+            # Collect positional arguments for legacy mode
+            POSITIONAL_COUNT=$((POSITIONAL_COUNT + 1))
+            case $POSITIONAL_COUNT in
+                1) VERSION="$1" ;;
+                2) APP_NAME="$1" ;;
+                3) APP_LONG_NAME="$1" ;;
+                *)
+                    echo "Error: Too many positional arguments" >&2
+                    show_usage
+                    exit 1
+                    ;;
+            esac
+            shift
+            ;;
+    esac
+done
+
+# Derive the long name from the app name if not set
+if [ -z "$APP_LONG_NAME" ] && [ -n "$APP_NAME" ]; then
+    APP_LONG_NAME="$APP_NAME Command Launcher"
+fi
+
+# Set defaults for missing arguments
+[ -z "$VERSION" ] && VERSION=$(default_version)
+[ -z "$APP_NAME" ] && APP_NAME=$DEFAULT_APP_NAME
+[ -z "$APP_LONG_NAME" ] && APP_LONG_NAME=$DEFAULT_APP_LONG_NAME
+[ -z "$OUTPUT" ] && OUTPUT=$APP_NAME
+[ -z "$BUILD_NUMBER" ] && BUILD_NUMBER=$(default_build_number)
+
+LD_FLAGS=""
+LD_FLAGS="$LD_FLAGS -X main.version=${VERSION}"
+LD_FLAGS="$LD_FLAGS -X main.buildNum=${BUILD_NUMBER}"
+LD_FLAGS="$LD_FLAGS -X main.appName=${APP_NAME}"
+LD_FLAGS="$LD_FLAGS -X 'main.appLongName=${APP_LONG_NAME}'"
+
+debug "Building $APP_NAME"
+debug "Version: $VERSION"
+debug "Build number: $BUILD_NUMBER"
+debug "App name: $APP_NAME"
+debug "App long name: $APP_LONG_NAME"
+debug "Output: $OUTPUT"
+
+go build -o "$OUTPUT" -ldflags="${LD_FLAGS}"

--- a/gh-pages/content/en/docs/overview/introduction.md
+++ b/gh-pages/content/en/docs/overview/introduction.md
@@ -83,6 +83,7 @@ go build -o cdt -ldflags='-X main.version=dev -X main.appName=cdt -X "main.appLo
 ```
 
 Or using the `build.sh` script
+
 ```shell
 ./build.sh -v VERSION -n APP_NAME -l APP_LONG_NAME
 ```

--- a/gh-pages/content/en/docs/overview/introduction.md
+++ b/gh-pages/content/en/docs/overview/introduction.md
@@ -82,10 +82,9 @@ You can build the command launcher with your preferred name (in the example: `Cr
 go build -o cdt -ldflags='-X main.version=dev -X main.appName=cdt -X "main.appLongName=Criteo Dev Toolkit"' main.go
 ```
 
-Or simply call the `build.sh` script
-
+Or using the `build.sh` script
 ```shell
-./build.sh [version] [app name] [app long name]
+./build.sh -v VERSION -n APP_NAME -l APP_LONG_NAME
 ```
 
 ## Running tests

--- a/gh-pages/content/en/docs/quickstart/build-from-source.md
+++ b/gh-pages/content/en/docs/quickstart/build-from-source.md
@@ -37,6 +37,7 @@ go build -o cola -ldflags='-X main.version=dev -X main.appName=cola -X "main.app
 ```
 
 Or using the `build.sh` script
+
 ```shell
 ./build.sh -v VERSION -n APP_NAME -l APP_LONG_NAME
 ```

--- a/gh-pages/content/en/docs/quickstart/build-from-source.md
+++ b/gh-pages/content/en/docs/quickstart/build-from-source.md
@@ -36,10 +36,9 @@ You can build the command launcher with your prefered name (in the example: `Com
 go build -o cola -ldflags='-X main.version=dev -X main.appName=cola -X "main.appLongName=Command Launcher"' main.go
 ```
 
-Or simply call the `build.sh` scripts
-
+Or using the `build.sh` script
 ```shell
-./build.sh [version] [app name] [app long name]
+./build.sh -v VERSION -n APP_NAME -l APP_LONG_NAME
 ```
 
 ## Run tests


### PR DESCRIPTION
## Summary

I wanted to be able to run the build script and just modify some of the parameters without having to follow the exact order of the positional arguments. I ended up keeping my own script and thought this could be a good addition to upstream.

Changes:
- Add named flags: `-v/--version`, `-n/--name`, `-l/--long-name`, `-o/--output`, `-b/--build-number`
- Add `-b/--build-number` flag so CI can pass `github.run_number` for stable build numbers instead of timestamps
- Incorporate upstream's `--resign` macOS code-signing feature as `-r/--resign`
- The legacy positional call format (`./build.sh VERSION NAME LONG_NAME [--resign]`) is preserved
- Update CI workflow to use `build.sh` with the new flags
- Update docs (README, introduction, build-from-source) with new usage

## I ran these tests:

- [x] All flag combinations (`-v`, `-n`, `-l`, `-o`, `-b`, `-r`, `-d`, `-h`)
- [x] Legacy positional argument mode (1, 2, and 3 args)
- [x] Legacy `--resign` as 4th positional arg
- [x] Error cases (unknown flags, too many positional args, missing values)
- [x] Verified embedded values in built binary (`myapp version 1.2.3, build 99`)
- [x] Verified `--resign` triggers `codesign` on macOS (replaces linker signature with ad-hoc codesign)