### PR TITLE
fix: pass user-provided arguments to commands verbatim

### DIFF
--- a/internal/command/default-command.go
+++ b/internal/command/default-command.go
@@ -119,9 +119,18 @@ func CmdReverseID(repo, pkg, group, name string) string {
 	return fmt.Sprintf("%s@%s@%s@%s", name, group, pkg, repo)
 }
 
-func (cmd *DefaultCommand) Execute(envVars []string, args ...string) (int, error) {
-	arguments := append(cmd.CmdArguments, args...)
+// effectiveArguments returns the manifest-defined arguments with template
+// variables interpolated, followed by the user-provided args verbatim.
+// User args must not be interpolated: they are arbitrary payloads, and the
+// manifest documentation scopes variables to manifest fields only.
+func (cmd *DefaultCommand) effectiveArguments(args ...string) []string {
+	arguments := append([]string{}, cmd.CmdArguments...)
 	cmd.interpolateArray(&arguments)
+	return append(arguments, args...)
+}
+
+func (cmd *DefaultCommand) Execute(envVars []string, args ...string) (int, error) {
+	arguments := cmd.effectiveArguments(args...)
 	command := cmd.interpolateCmd()
 
 	log.Debug("Command line: ", command, " ", arguments)
@@ -183,8 +192,7 @@ func (cmd *DefaultCommand) ExecuteWithOutput(envVars []string, args ...string) (
 	if err != nil {
 		return 1, "", err
 	}
-	arguments := append(cmd.CmdArguments, args...)
-	cmd.interpolateArray(&arguments)
+	arguments := cmd.effectiveArguments(args...)
 	command := cmd.interpolateCmd()
 
 	env := append(os.Environ(), envVars...)

--- a/internal/command/default-command_test.go
+++ b/internal/command/default-command_test.go
@@ -225,6 +225,34 @@ func TestInterpolate(t *testing.T) {
 	assert.Equal(t, "/tmp/test/root/windows/x64/test.exe", cmd.doInterpolate("windows", "x64", "#CACHE#/#OS#/#ARCH#/test#EXT#"))
 }
 
+func TestEffectiveArgumentsUserArgsVerbatim(t *testing.T) {
+	cmd := getDefaultCommand()
+	cmd.CmdArguments = []string{}
+
+	userArgs := []string{"a < b", "{{.Os}}", "#OS#", "&lt;", "x  y", "a {{ b"}
+	result := cmd.effectiveArguments(userArgs...)
+
+	assert.Equal(t, userArgs, result, "user args must reach the executable byte-for-byte")
+}
+
+func TestEffectiveArgumentsInterpolatesManifestArgs(t *testing.T) {
+	cmd := getDefaultCommand()
+	cmd.CmdArguments = []string{"{{.Os}}"}
+
+	result := cmd.effectiveArguments("#OS#", "{{.Os}}")
+
+	assert.Equal(t, []string{runtime.GOOS, "#OS#", "{{.Os}}"}, result)
+}
+
+func TestEffectiveArgumentsDoesNotMutateManifest(t *testing.T) {
+	cmd := getDefaultCommand()
+	cmd.CmdArguments = []string{"{{.Os}}", "#OS#"}
+
+	cmd.effectiveArguments("user")
+
+	assert.Equal(t, []string{"{{.Os}}", "#OS#"}, cmd.CmdArguments, "manifest args must not be mutated by execution")
+}
+
 func TestRuntimeNameAndGroup(t *testing.T) {
 	cmd := getDefaultCommand()
 


### PR DESCRIPTION
`Execute` and `ExecuteWithOutput` interpolated the full argument list (manifest-defined args and user-typed ones alike) so a user payload with a stray '<' was rewritten to '&lt;', '{{...}}' was executed as a template action, and '#OS#' was substituted. The manifest documentation scopes variables to manifest fields only.

Add an `effectiveArguments` helper that copies `CmdArguments`, interpolates the copy, then appends user args verbatim.