### PR TITLE
Lazy setup feature: new parameter to run setup phase on first run of command 

### DIFF
--- a/cmd/package-mgmt.go
+++ b/cmd/package-mgmt.go
@@ -451,9 +451,27 @@ func printPackageDetails(pkg command.PackageManifest, source *backend.PackageSou
 		}
 	}
 
+	fmt.Printf("  Setup:      %s\n", setupState(pkg))
+
 	fmt.Println()
 	fmt.Println("  Commands:")
 	printCommands(pkg.Commands())
+}
+
+// setupState describes whether the package's __setup__ hook has run, based on the
+// .setup marker written in the package directory.
+func setupState(mf command.PackageManifest) string {
+	if !pkg.HasSetupHook(mf) {
+		return "n/a (no __setup__ hook)"
+	}
+	cmds := mf.Commands()
+	if len(cmds) == 0 || cmds[0].PackageDir() == "" {
+		return "unknown"
+	}
+	if pkg.IsSetupDone(cmds[0].PackageDir()) {
+		return "done"
+	}
+	return "pending"
 }
 
 func findPackageFolder(pkgName string) (string, error) {

--- a/gh-pages/content/en/docs/overview/config.md
+++ b/gh-pages/content/en/docs/overview/config.md
@@ -47,6 +47,7 @@ toc: true
 | enable_package_setup_hook        | bool     | call setup hook after a new version of package is installed (available 1.9+)                                                  |
 | group_help_by_registry           | bool     | group help by registry, default true (available 1.13+)                                                                        |
 | enable_workspace_packages        | bool     | enable or disable workspace package discovery, default false (available 1.15+)                                                |
+| enable_lazy_setup                | bool     | run the package setup hook before the first command of the package if not done yet, default false (available 1.16+)          |
 
 ### extra remote configuration
 

--- a/gh-pages/content/en/docs/overview/manifest.md
+++ b/gh-pages/content/en/docs/overview/manifest.md
@@ -557,6 +557,12 @@ When a package is installed, sometimes it requires some setup to make it work pr
 
 > Make sure the setup hook is _idempotent_, when a new version is installed the setup hook will be called again.
 
+Once the setup hook has run successfully, Command Launcher writes a `.setup` marker file in the package folder. The marker is a small JSON document (`completedAt`, `packageVersion`) and is removed together with the package folder when the package is uninstalled or updated. Remove it manually to force the setup to run again. The built-in `cola package inspect [package_name]` shows the setup state (`done`, `pending`, or `n/a` when the package has no `__setup__` hook).
+
+**Lazy setup:** when the configuration `enable_lazy_setup` is `true` (default `false`), Command Launcher runs the `__setup__` hook of a package right before the first command of that package is called, if the setup has not been done yet (no `.setup` marker). This is useful when the setup hook is not run at installation time (`enable_package_setup_hook` is `false` by default), or when the package is installed by simply dropping it in the dropin folder. `enable_lazy_setup` is independent from `enable_package_setup_hook`, which only controls the setup at installation time; packages without a `__setup__` hook are not affected.
+
+> The lazy setup hook runs in the same terminal as the command: its output is mixed with the command output, so keep the hook quiet if the command output is meant to be parsed. The hook only receives the process environment (not the `COLA_*` variables), use `{{.PackageDir}}` to locate the package folder. For [workspace packages](../workspace), add `.setup` to your `.gitignore`.
+
 **Example:**
 
 ```yaml

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -116,6 +116,7 @@ func setDefaultConfig() {
 
 	viper.SetDefault(EXTRA_REMOTES_KEY, []map[string]string{})
 	viper.SetDefault(ENABLE_PACKAGE_SETUP_HOOK_KEY, false)
+	viper.SetDefault(ENABLE_LAZY_SETUP_KEY, false)
 
 	// by default, group the top level command by registry in the help message
 	viper.SetDefault(GROUP_HELP_BY_REGISTRY_KEY, true)

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -37,6 +37,7 @@ const (
 	EXTRA_REMOTE_REPOSITORY_DIR_KEY      = "REPOSITORY_DIR"
 	EXTRA_REMOTE_SYNC_POLICY_KEY         = "SYNC_POLICY"
 	ENABLE_PACKAGE_SETUP_HOOK_KEY        = "ENABLE_PACKAGE_SETUP_HOOK"
+	ENABLE_LAZY_SETUP_KEY                = "ENABLE_LAZY_SETUP"
 	GROUP_HELP_BY_REGISTRY_KEY           = "GROUP_HELP_BY_REGISTRY"
 	ENABLE_WORKSPACE_PACKAGES_KEY        = "ENABLE_WORKSPACE_PACKAGES"
 
@@ -79,6 +80,7 @@ func init() {
 		SYSTEM_PACKAGE_KEY,
 		SYSTEM_PACKAGE_PUBLIC_KEY_FILE_KEY,
 		ENABLE_PACKAGE_SETUP_HOOK_KEY,
+		ENABLE_LAZY_SETUP_KEY,
 		GROUP_HELP_BY_REGISTRY_KEY,
 		ENABLE_WORKSPACE_PACKAGES_KEY,
 	)
@@ -136,6 +138,8 @@ func SetSettingValue(key string, value string) error {
 	case VERIFY_PACKAGE_SIGNATURE_KEY:
 		return setBooleanConfig(upperKey, value)
 	case ENABLE_PACKAGE_SETUP_HOOK_KEY:
+		return setBooleanConfig(upperKey, value)
+	case ENABLE_LAZY_SETUP_KEY:
 		return setBooleanConfig(upperKey, value)
 	case GROUP_HELP_BY_REGISTRY_KEY:
 		return setBooleanConfig(upperKey, value)

--- a/internal/frontend/default-frontend.go
+++ b/internal/frontend/default-frontend.go
@@ -15,6 +15,7 @@ import (
 	"github.com/criteo/command-launcher/internal/console"
 	"github.com/criteo/command-launcher/internal/context"
 	"github.com/criteo/command-launcher/internal/helper"
+	"github.com/criteo/command-launcher/internal/pkg"
 
 	log "github.com/sirupsen/logrus"
 
@@ -331,6 +332,19 @@ func (self *defaultFrontend) executeCommand(group, name string, args []string, i
 		}
 	}
 
+	// Lazy setup: when enabled by the user (ENABLE_LAZY_SETUP), run the __setup__ hook of
+	// the command's package before the command if it has not been done yet. The package
+	// dir must be known so the marker is never looked up or written relative to the cwd.
+	if viper.GetBool(config.ENABLE_LAZY_SETUP_KEY) {
+		if iCmd.PackageDir() == "" {
+			log.Warnf("package %s has no package directory, skipping lazy setup", iCmd.PackageName())
+		} else if !pkg.IsSetupDone(iCmd.PackageDir()) {
+			if err := self.runLazySetup(iCmd); err != nil {
+				return 1, fmt.Errorf("lazy setup failed for package %s: %v", iCmd.PackageName(), err)
+			}
+		}
+	}
+
 	envCtx := self.getCmdEnvContext(iCmd, initialEnvCtx, userConsent)
 
 	exitCode, err := iCmd.Execute(envCtx, args...)
@@ -339,6 +353,25 @@ func (self *defaultFrontend) executeCommand(group, name string, args []string, i
 	}
 
 	return exitCode, nil
+}
+
+// runLazySetup runs the __setup__ hook of the package that owns iCmd before the
+// command executes. Packages without a __setup__ hook are left untouched (no marker).
+func (self *defaultFrontend) runLazySetup(iCmd command.Command) error {
+	for _, src := range self.backend.AllPackageSources() {
+		if src.Repo == nil || src.Name != iCmd.RepositoryID() {
+			continue
+		}
+		manifest, err := src.Repo.Package(iCmd.PackageName())
+		if err != nil {
+			return err
+		}
+		if !pkg.HasSetupHook(manifest) {
+			return nil
+		}
+		return pkg.ExecSetupHookFromPackage(manifest, iCmd.PackageDir())
+	}
+	return fmt.Errorf("cannot find package %s to run its setup", iCmd.PackageName())
 }
 
 // execute the valid args command of the cdt command

--- a/internal/frontend/lazy_setup_test.go
+++ b/internal/frontend/lazy_setup_test.go
@@ -1,0 +1,142 @@
+package frontend
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/criteo/command-launcher/internal/backend"
+	"github.com/criteo/command-launcher/internal/command"
+	"github.com/criteo/command-launcher/internal/config"
+	"github.com/criteo/command-launcher/internal/context"
+	"github.com/criteo/command-launcher/internal/pkg"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// makePackageSource writes a package manifest.mf under dir/pkgName with an
+// executable command (named cmdName) and, when withHook is set, a __setup__ hook
+// that appends a line to <pkgDir>/setup.count.
+func makePackageSource(t *testing.T, name string, dir string, pkgName string, cmdName string, withHook bool) *backend.PackageSource {
+	t.Helper()
+	pkgDir := filepath.Join(dir, pkgName)
+	err := os.MkdirAll(pkgDir, 0755)
+	assert.Nil(t, err)
+
+	hook := ""
+	if withHook {
+		hook = `{"name": "__setup__", "type": "system", "executable": "sh", "args": ["-c", "echo run >> #CACHE#/setup.count"]},`
+	}
+	manifest := `{
+  "pkgName": "` + pkgName + `",
+  "version": "1.0.0",
+  "cmds": [
+    ` + hook + `
+    {"name": "` + cmdName + `", "type": "executable", "group": "", "short": "test", "executable": "echo"}
+  ]
+}`
+	err = os.WriteFile(filepath.Join(pkgDir, "manifest.mf"), []byte(manifest), 0644)
+	assert.Nil(t, err)
+
+	return &backend.PackageSource{
+		Name:       name,
+		RepoDir:    dir,
+		SyncPolicy: backend.SYNC_POLICY_NEVER,
+		IsManaged:  false,
+	}
+}
+
+// newLazySetupFrontend builds a real backend from two on-disk packages: "run" belongs
+// to a package with a __setup__ hook, "nohook" to a package without one.
+func newLazySetupFrontend(t *testing.T) (*defaultFrontend, command.Command, command.Command) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the __setup__ fixture requires sh")
+	}
+
+	homeDir := t.TempDir()
+	dropinDir := t.TempDir()
+	defaultDir := t.TempDir()
+
+	dropinSrc := makePackageSource(t, "dropin", dropinDir, "nohook-pkg", "nohook", false)
+	defaultSrc := makePackageSource(t, "default", defaultDir, "lazy-pkg", "run", true)
+
+	be, err := backend.NewDefaultBackend(homeDir, nil, dropinSrc, defaultSrc)
+	assert.Nil(t, err)
+
+	fe := &defaultFrontend{backend: be, appCtx: context.InitContext("cdt", "1.0.0", "0")}
+
+	runCmd, err := be.FindCommand("", "run")
+	assert.Nil(t, err)
+	nohookCmd, err := be.FindCommand("", "nohook")
+	assert.Nil(t, err)
+
+	return fe, runCmd, nohookCmd
+}
+
+func setLazySetupConfig(t *testing.T, enabled bool) {
+	t.Helper()
+	previous := viper.GetBool(config.ENABLE_LAZY_SETUP_KEY)
+	viper.Set(config.ENABLE_LAZY_SETUP_KEY, enabled)
+	t.Cleanup(func() { viper.Set(config.ENABLE_LAZY_SETUP_KEY, previous) })
+}
+
+func TestLazySetup_RunsOnceBeforeCommand(t *testing.T) {
+	fe, iCmd, _ := newLazySetupFrontend(t)
+	setLazySetupConfig(t, true)
+
+	pkgDir := iCmd.PackageDir()
+	countFile := filepath.Join(pkgDir, "setup.count")
+
+	// setup hasn't run yet
+	_, err := os.Stat(countFile)
+	assert.True(t, os.IsNotExist(err))
+	assert.False(t, pkg.IsSetupDone(pkgDir))
+
+	exitCode, err := fe.executeCommand("", "run", []string{}, []string{}, []string{})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	data, err := os.ReadFile(countFile)
+	assert.Nil(t, err)
+	assert.Equal(t, "run\n", string(data))
+	assert.True(t, pkg.IsSetupDone(pkgDir))
+
+	// second invocation must not re-run setup
+	exitCode, err = fe.executeCommand("", "run", []string{}, []string{}, []string{})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	data, err = os.ReadFile(countFile)
+	assert.Nil(t, err)
+	assert.Equal(t, "run\n", string(data))
+}
+
+func TestLazySetup_PackageWithoutHook(t *testing.T) {
+	fe, _, nohookCmd := newLazySetupFrontend(t)
+	setLazySetupConfig(t, true)
+
+	// the command runs and no marker is written for a package without __setup__
+	exitCode, err := fe.executeCommand("", "nohook", []string{}, []string{}, []string{})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.False(t, pkg.IsSetupDone(nohookCmd.PackageDir()))
+}
+
+func TestLazySetup_DisabledByConfig(t *testing.T) {
+	fe, iCmd, _ := newLazySetupFrontend(t)
+	setLazySetupConfig(t, false)
+
+	pkgDir := iCmd.PackageDir()
+	countFile := filepath.Join(pkgDir, "setup.count")
+
+	// the command still runs, but the setup hook is not triggered and no marker is written
+	exitCode, err := fe.executeCommand("", "run", []string{}, []string{}, []string{})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	_, err = os.Stat(countFile)
+	assert.True(t, os.IsNotExist(err))
+	assert.False(t, pkg.IsSetupDone(pkgDir))
+}

--- a/internal/pkg/assets/fake-good-setup/manifest.mf
+++ b/internal/pkg/assets/fake-good-setup/manifest.mf
@@ -1,0 +1,12 @@
+{
+    "pkgName": "fake-good-setup",
+    "version": "1.0.0",
+    "cmds": [
+	    {
+            "name": "__setup__",
+            "type": "system",
+            "executable": "echo",
+            "args": [ "setup" ]
+        }
+    ]
+}

--- a/internal/pkg/default-package.go
+++ b/internal/pkg/default-package.go
@@ -153,9 +153,32 @@ func ExecSetupHookFromPackage(pkg command.PackageManifest, pkgDir string) error 
 			if err != nil {
 				return fmt.Errorf("setup hook of package %s failed to execute: %v", pkg.Name(), err)
 			}
+			if err := MarkSetupDone(c.PackageDir(), pkg.Version()); err != nil {
+				log.Warnf("failed to write setup marker for package %s: %v", pkg.Name(), err)
+			}
 			return nil
 		}
 	}
 	log.Warnf("No setup hook defined for package %s", pkg.Name())
+	if dir := effectivePackageDir(pkg, pkgDir); dir != "" {
+		if err := MarkSetupDone(dir, pkg.Version()); err != nil {
+			log.Warnf("failed to write setup marker for package %s: %v", pkg.Name(), err)
+		}
+	}
 	return nil
+}
+
+// effectivePackageDir returns pkgDir when provided, otherwise falls back to the
+// package directory already set on one of its commands (populated when the
+// package was loaded/registered).
+func effectivePackageDir(pkg command.PackageManifest, pkgDir string) string {
+	if pkgDir != "" {
+		return pkgDir
+	}
+	for _, c := range pkg.Commands() {
+		if c.PackageDir() != "" {
+			return c.PackageDir()
+		}
+	}
+	return ""
 }

--- a/internal/pkg/default-package.go
+++ b/internal/pkg/default-package.go
@@ -142,9 +142,26 @@ func copyFile(src string, dst string) error {
 	return os.Chmod(dst, srcInfo.Mode())
 }
 
+// SETUP_HOOK_NAME is the name of the system command a package may define as its setup hook.
+const SETUP_HOOK_NAME = "__setup__"
+
+func isSetupHook(c command.Command) bool {
+	return c.Name() == SETUP_HOOK_NAME && c.Type() == "system"
+}
+
+// HasSetupHook reports whether the package defines a __setup__ system command.
+func HasSetupHook(pkg command.PackageManifest) bool {
+	for _, c := range pkg.Commands() {
+		if isSetupHook(c) {
+			return true
+		}
+	}
+	return false
+}
+
 func ExecSetupHookFromPackage(pkg command.PackageManifest, pkgDir string) error {
 	for _, c := range pkg.Commands() {
-		if c.Name() == "__setup__" && c.Type() == "system" {
+		if isSetupHook(c) {
 			if pkgDir != "" {
 				c.SetPackageDir(pkgDir)
 			}

--- a/internal/pkg/default-package_test.go
+++ b/internal/pkg/default-package_test.go
@@ -26,6 +26,16 @@ func TestReadManifest(t *testing.T) {
 	assert.Equal(t, 2, len(cmds[0].Arguments()))
 }
 
+func TestHasSetupHook(t *testing.T) {
+	withHook, err := CreateFolderPackage("assets/fake-good-setup")
+	assert.Nil(t, err)
+	assert.True(t, HasSetupHook(withHook))
+
+	withoutHook, err := CreateFolderPackage("assets/folder-package")
+	assert.Nil(t, err)
+	assert.False(t, HasSetupHook(withoutHook))
+}
+
 func TestReadManifestInYaml(t *testing.T) {
 	file, _ := os.Open("assets/fake-yaml.mf")
 	mf, err := ReadManifest(file)

--- a/internal/pkg/folder-package_test.go
+++ b/internal/pkg/folder-package_test.go
@@ -63,3 +63,25 @@ func TestFolder_InstallToWithSetupError(t *testing.T) {
 	assert.Contains(t, err.Error(), fmt.Sprintf("setup hook of package %s failed to execute", p.Name()))
 	assert.Nil(t, mf)
 }
+
+func TestFolder_InstallToWithSetupSuccess(t *testing.T) {
+	p, err := CreateFolderPackage("assets/fake-good-setup")
+	assert.NotNil(t, p)
+	assert.Nil(t, err)
+
+	targetDir := t.TempDir()
+
+	var previousSetupHook = viper.GetBool(config.ENABLE_PACKAGE_SETUP_HOOK_KEY)
+	defer viper.Set(config.ENABLE_PACKAGE_SETUP_HOOK_KEY, previousSetupHook)
+	viper.Set(config.ENABLE_PACKAGE_SETUP_HOOK_KEY, true)
+
+	mf, err := p.InstallTo(targetDir)
+	assert.Nil(t, err)
+	assert.NotNil(t, mf)
+
+	pkgDir := filepath.Join(targetDir, p.Name())
+	assert.True(t, IsSetupDone(pkgDir))
+
+	_, err = os.Stat(filepath.Join(pkgDir, SETUP_MARKER_FILE))
+	assert.Nil(t, err)
+}

--- a/internal/pkg/setup-marker.go
+++ b/internal/pkg/setup-marker.go
@@ -1,0 +1,39 @@
+package pkg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// SETUP_MARKER_FILE is the name of the file written into a package directory
+// once its __setup__ hook has completed successfully.
+const SETUP_MARKER_FILE = ".setup"
+
+// SetupMarker records that a package's setup phase has run.
+type SetupMarker struct {
+	CompletedAt    time.Time `json:"completedAt"`
+	PackageVersion string    `json:"packageVersion"`
+}
+
+// IsSetupDone reports whether the setup marker exists in pkgDir.
+func IsSetupDone(pkgDir string) bool {
+	_, err := os.Stat(filepath.Join(pkgDir, SETUP_MARKER_FILE))
+	return err == nil
+}
+
+// MarkSetupDone writes the setup marker file into pkgDir.
+func MarkSetupDone(pkgDir string, packageVersion string) error {
+	marker := SetupMarker{
+		CompletedAt:    time.Now(),
+		PackageVersion: packageVersion,
+	}
+
+	data, err := json.MarshalIndent(marker, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(pkgDir, SETUP_MARKER_FILE), data, 0644)
+}

--- a/internal/pkg/setup-marker.go
+++ b/internal/pkg/setup-marker.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -18,13 +19,21 @@ type SetupMarker struct {
 }
 
 // IsSetupDone reports whether the setup marker exists in pkgDir.
+// An empty pkgDir never counts as done (and is never looked up relative to the cwd).
 func IsSetupDone(pkgDir string) bool {
+	if pkgDir == "" {
+		return false
+	}
 	_, err := os.Stat(filepath.Join(pkgDir, SETUP_MARKER_FILE))
 	return err == nil
 }
 
 // MarkSetupDone writes the setup marker file into pkgDir.
+// It refuses an empty pkgDir so the marker can never land in the process cwd.
 func MarkSetupDone(pkgDir string, packageVersion string) error {
+	if pkgDir == "" {
+		return fmt.Errorf("cannot write setup marker: empty package directory")
+	}
 	marker := SetupMarker{
 		CompletedAt:    time.Now(),
 		PackageVersion: packageVersion,

--- a/internal/pkg/setup-marker_test.go
+++ b/internal/pkg/setup-marker_test.go
@@ -1,0 +1,57 @@
+package pkg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSetupDone_NotExists(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	assert.False(t, IsSetupDone(tmpDir))
+}
+
+func TestMarkSetupDone(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := MarkSetupDone(tmpDir, "1.2.3")
+	assert.NoError(t, err)
+
+	assert.True(t, IsSetupDone(tmpDir))
+
+	markerFile := filepath.Join(tmpDir, SETUP_MARKER_FILE)
+	data, err := os.ReadFile(markerFile)
+	assert.NoError(t, err)
+
+	var marker SetupMarker
+	err = json.Unmarshal(data, &marker)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3", marker.PackageVersion)
+	assert.False(t, marker.CompletedAt.IsZero())
+}
+
+func TestIsSetupDone_Table(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupDone bool
+		expected  bool
+	}{
+		{name: "no marker written", setupDone: false, expected: false},
+		{name: "marker written", setupDone: true, expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			if tt.setupDone {
+				err := MarkSetupDone(tmpDir, "1.0.0")
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, IsSetupDone(tmpDir))
+		})
+	}
+}

--- a/internal/pkg/setup-marker_test.go
+++ b/internal/pkg/setup-marker_test.go
@@ -34,6 +34,25 @@ func TestMarkSetupDone(t *testing.T) {
 	assert.False(t, marker.CompletedAt.IsZero())
 }
 
+// An empty package directory must never be resolved relative to the cwd.
+func TestSetupMarker_EmptyDir(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	tmpDir := t.TempDir()
+	assert.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	assert.False(t, IsSetupDone(""))
+
+	err = MarkSetupDone("", "1.0.0")
+	assert.Error(t, err)
+
+	// nothing was written in the cwd
+	_, err = os.Stat(filepath.Join(tmpDir, SETUP_MARKER_FILE))
+	assert.True(t, os.IsNotExist(err))
+	assert.False(t, IsSetupDone(""))
+}
+
 func TestIsSetupDone_Table(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,13 @@
+1.16.0:
+  version: 1.16.0
+  releaseNotes: |
+    # ✨ New Features
+      * Record that a package `__setup__` hook has run with a `.setup` marker file in the package folder.
+      * Lazy setup: run the package setup hook right before the first command of the package when it has not run yet. Enable with `cdt config ENABLE_LAZY_SETUP true`.
+      * `package inspect` now shows the package setup state (done / pending / n/a).
+  startPartition: 0
+  endPartition: 9
+
 1.15.2:
   version: 1.15.2
   releaseNotes: |

--- a/test/integration/test-lazy-setup.sh
+++ b/test/integration/test-lazy-setup.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+# Test: ENABLE_LAZY_SETUP config (run the package __setup__ hook before a command) + .setup marker
+#
+# availeble environment varibale
+# CL_PATH: the path of the command launcher binary
+# CL_HOME: the path of the command launcher home directory
+# OUTPUT_DIR: the output folder
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# clean up the dropin folder and the configuration
+rm -rf $CL_HOME/dropins
+rm -f $CL_HOME/config.json
+mkdir -p $CL_HOME/dropins
+
+# copy the test packages to the dropin folder
+cp -R $SCRIPT_DIR/../packages-src/lazy-setup $CL_HOME/dropins
+cp -R $SCRIPT_DIR/../packages-src/lazy-setup-fail $CL_HOME/dropins
+cp -R $SCRIPT_DIR/../packages-src/lazy-setup-nohook $CL_HOME/dropins
+cp -R $SCRIPT_DIR/../packages-src/bonjour $CL_HOME/dropins
+
+PKG=$CL_HOME/dropins/lazy-setup
+PKG_FAIL=$CL_HOME/dropins/lazy-setup-fail
+PKG_NOHOOK=$CL_HOME/dropins/lazy-setup-nohook
+
+# helpers
+ok() { echo "OK"; }
+ko() { echo "KO - $1"; exit 1; }
+# number of lines in the setup counter file (0 when absent)
+setup_count() {
+  if [ -f "$PKG/setup.count" ]; then
+    wc -l < "$PKG/setup.count" | tr -d ' '
+  else
+    echo 0
+  fi
+}
+expect_count() {
+  COUNT=$(setup_count)
+  if [ "$COUNT" == "$1" ]; then ok; else ko "setup hook should have run $1 time(s), got $COUNT"; fi
+}
+
+################
+echo "> test lazy setup is disabled by default"
+RESULT=$($CL_PATH lazy-hello)
+EXIT_CODE=$?
+
+echo "* command should succeed"
+[ $EXIT_CODE -eq 0 ] && ok || ko "lazy-hello should exit 0"
+
+echo "* command output should be printed"
+echo "$RESULT" | grep -q "hello lazy" && ok || ko "should print hello lazy"
+
+echo "* setup hook should NOT be called when enable_lazy_setup is false"
+echo "$RESULT" | grep -q "calling lazy setup" && ko "setup hook should not be called" || ok
+
+echo "* no setup marker should be written"
+[ ! -f "$PKG/.setup" ] && ok || ko ".setup should not exist"
+expect_count 0
+
+################
+echo "> test enable lazy setup"
+$CL_PATH config enable_lazy_setup true
+RESULT=$($CL_PATH config enable_lazy_setup)
+echo "$RESULT" | grep -q "true" && ok || ko "enable_lazy_setup should be true"
+
+################
+echo "> test first command of the package runs setup"
+RESULT=$($CL_PATH lazy-hello)
+EXIT_CODE=$?
+
+echo "* command should succeed"
+[ $EXIT_CODE -eq 0 ] && ok || ko "lazy-hello should exit 0"
+
+echo "* setup hook should be called before the command"
+echo "$RESULT" | grep -q "calling lazy setup" && ok || ko "setup hook should be called"
+
+echo "* command output should be printed"
+echo "$RESULT" | grep -q "hello lazy" && ok || ko "should print hello lazy"
+
+echo "* setup marker should be written in the package folder"
+[ -f "$PKG/.setup" ] && ok || ko ".setup should exist"
+
+echo "* setup marker should record the package version"
+grep -q '"packageVersion": "1.0.0"' "$PKG/.setup" && ok || ko ".setup should contain the package version"
+
+echo "* setup hook should have run once"
+expect_count 1
+
+################
+echo "> test second command of the package does not re-run setup"
+RESULT=$($CL_PATH lazy-hello)
+
+echo "* setup hook should NOT be called again"
+echo "$RESULT" | grep -q "calling lazy setup" && ko "setup hook should not be called again" || ok
+
+echo "* command output should be printed"
+echo "$RESULT" | grep -q "hello lazy" && ok || ko "should print hello lazy"
+
+echo "* setup hook should still have run once"
+expect_count 1
+
+################
+echo "> test removing the marker re-runs setup"
+rm -f "$PKG/.setup"
+RESULT=$($CL_PATH lazy-hello)
+
+echo "* setup hook should be called again"
+echo "$RESULT" | grep -q "calling lazy setup" && ok || ko "setup hook should be called after marker removal"
+
+echo "* setup marker should be written again"
+[ -f "$PKG/.setup" ] && ok || ko ".setup should exist"
+expect_count 2
+
+################
+echo "> test failing lazy setup blocks the command"
+RESULT=$($CL_PATH lazy-fail 2>&1)
+EXIT_CODE=$?
+
+echo "* command should fail"
+[ $EXIT_CODE -ne 0 ] && ok || ko "lazy-fail should exit with a non-zero code"
+
+echo "* error should mention the lazy setup failure"
+echo "$RESULT" | grep -q "lazy setup failed" && ok || ko "should report lazy setup failure"
+
+echo "* the command itself should NOT run"
+echo "$RESULT" | grep -q "should not run" && ko "command should not run when setup fails" || ok
+
+echo "* no setup marker should be written"
+[ ! -f "$PKG_FAIL/.setup" ] && ok || ko ".setup should not exist after a failed setup"
+
+################
+echo "> test manual package setup writes the marker"
+rm -f "$PKG/.setup"
+RESULT=$($CL_PATH package setup lazy-setup)
+EXIT_CODE=$?
+
+echo "* package setup should succeed"
+[ $EXIT_CODE -eq 0 ] && ok || ko "package setup lazy-setup should exit 0"
+
+echo "* setup marker should be written"
+[ -f "$PKG/.setup" ] && ok || ko ".setup should exist after package setup"
+expect_count 3
+
+echo "* the command should not re-run setup after a manual setup"
+RESULT=$($CL_PATH lazy-hello)
+echo "$RESULT" | grep -q "calling lazy setup" && ko "setup hook should not be called" || ok
+expect_count 3
+
+echo "* package setup of a failing hook should fail"
+RESULT=$($CL_PATH package setup lazy-setup-fail 2>&1)
+[ $? -ne 0 ] && ok || ko "package setup lazy-setup-fail should exit with a non-zero code"
+
+################
+echo "> test command in a package without setup hook"
+RESULT=$($CL_PATH lazy-nohook)
+EXIT_CODE=$?
+
+echo "* command should succeed"
+[ $EXIT_CODE -eq 0 ] && ok || ko "lazy-nohook should exit 0"
+
+echo "* command output should be printed"
+echo "$RESULT" | grep -q "hello nohook" && ok || ko "should print hello nohook"
+
+echo "* no setup marker should be written for a package without hook"
+[ ! -f "$PKG_NOHOOK/.setup" ] && ok || ko ".setup should not exist"
+
+################
+echo "> test package inspect shows the setup state"
+RESULT=$($CL_PATH package inspect lazy-setup)
+echo "* should show setup done"
+echo "$RESULT" | grep -q "Setup:.*done" && ok || ko "lazy-setup should show Setup: done"
+
+RESULT=$($CL_PATH package inspect lazy-setup-fail)
+echo "* should show setup pending"
+echo "$RESULT" | grep -q "Setup:.*pending" && ok || ko "lazy-setup-fail should show Setup: pending"
+
+RESULT=$($CL_PATH package inspect bonjour)
+echo "* should show setup n/a for a package without hook"
+echo "$RESULT" | grep -q "Setup:.*n/a" && ok || ko "bonjour should show Setup: n/a"
+
+################
+echo "> test lazy setup is independent from the install-time setup hook config"
+$CL_PATH config enable_package_setup_hook false
+rm -f "$PKG/.setup"
+RESULT=$($CL_PATH lazy-hello)
+
+echo "* setup hook should be called even with enable_package_setup_hook false"
+echo "$RESULT" | grep -q "calling lazy setup" && ok || ko "lazy setup should not depend on enable_package_setup_hook"
+expect_count 4
+
+################
+echo "> test disabling lazy setup again"
+$CL_PATH config enable_lazy_setup false
+rm -f "$PKG/.setup"
+RESULT=$($CL_PATH lazy-hello)
+
+echo "* setup hook should NOT be called"
+echo "$RESULT" | grep -q "calling lazy setup" && ko "setup hook should not be called when disabled" || ok
+expect_count 4

--- a/test/packages-src/lazy-setup-fail/hello.bat
+++ b/test/packages-src/lazy-setup-fail/hello.bat
@@ -1,0 +1,2 @@
+@ECHO off
+ECHO should not run

--- a/test/packages-src/lazy-setup-fail/hello.sh
+++ b/test/packages-src/lazy-setup-fail/hello.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "should not run"

--- a/test/packages-src/lazy-setup-fail/manifest.mf
+++ b/test/packages-src/lazy-setup-fail/manifest.mf
@@ -1,0 +1,17 @@
+{
+  "pkgName": "lazy-setup-fail",
+  "version": "1.0.0",
+  "cmds": [
+    {
+      "name": "__setup__",
+      "type": "system",
+      "executable": "{{.PackageDir}}/setup.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}"
+    },
+    {
+      "name": "lazy-fail",
+      "type": "executable",
+      "short": "command from a package whose setup hook always fails",
+      "executable": "{{.PackageDir}}/hello.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}"
+    }
+  ]
+}

--- a/test/packages-src/lazy-setup-fail/setup.bat
+++ b/test/packages-src/lazy-setup-fail/setup.bat
@@ -1,0 +1,3 @@
+@ECHO off
+ECHO failing setup
+EXIT 1

--- a/test/packages-src/lazy-setup-fail/setup.sh
+++ b/test/packages-src/lazy-setup-fail/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "failing setup"
+exit 1

--- a/test/packages-src/lazy-setup-nohook/hello.bat
+++ b/test/packages-src/lazy-setup-nohook/hello.bat
@@ -1,0 +1,2 @@
+@ECHO off
+ECHO hello nohook

--- a/test/packages-src/lazy-setup-nohook/hello.sh
+++ b/test/packages-src/lazy-setup-nohook/hello.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hello nohook"

--- a/test/packages-src/lazy-setup-nohook/manifest.mf
+++ b/test/packages-src/lazy-setup-nohook/manifest.mf
@@ -1,0 +1,12 @@
+{
+  "pkgName": "lazy-setup-nohook",
+  "version": "1.0.0",
+  "cmds": [
+    {
+      "name": "lazy-nohook",
+      "type": "executable",
+      "short": "command from a package without a __setup__ hook",
+      "executable": "{{.PackageDir}}/hello.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}"
+    }
+  ]
+}

--- a/test/packages-src/lazy-setup/hello.bat
+++ b/test/packages-src/lazy-setup/hello.bat
@@ -1,0 +1,2 @@
+@ECHO off
+ECHO hello lazy

--- a/test/packages-src/lazy-setup/hello.sh
+++ b/test/packages-src/lazy-setup/hello.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hello lazy"

--- a/test/packages-src/lazy-setup/manifest.mf
+++ b/test/packages-src/lazy-setup/manifest.mf
@@ -1,0 +1,17 @@
+{
+  "pkgName": "lazy-setup",
+  "version": "1.0.0",
+  "cmds": [
+    {
+      "name": "__setup__",
+      "type": "system",
+      "executable": "{{.PackageDir}}/setup.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}"
+    },
+    {
+      "name": "lazy-hello",
+      "type": "executable",
+      "short": "print hello from a package with a setup hook",
+      "executable": "{{.PackageDir}}/hello.{{if eq .Os \"windows\"}}bat{{else}}sh{{end}}"
+    }
+  ]
+}

--- a/test/packages-src/lazy-setup/setup.bat
+++ b/test/packages-src/lazy-setup/setup.bat
@@ -1,0 +1,3 @@
+@ECHO off
+ECHO calling lazy setup
+ECHO run>> "%~dp0setup.count"

--- a/test/packages-src/lazy-setup/setup.sh
+++ b/test/packages-src/lazy-setup/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# the setup hook only receives the process environment, so locate the package dir from $0
+echo "calling lazy setup"
+echo run >> "$(dirname "$0")/setup.count"


### PR DESCRIPTION
### What

- **`.setup` marker** — once a package's `__setup__` hook succeeds (at install time, via `cdt package setup`, or lazily), a small JSON marker (`completedAt`, `packageVersion`) is written in the package folder. It is removed with the folder on uninstall/update; delete it to force a re-run.
- **Lazy setup (`enable_lazy_setup`, default `false`)** — when enabled, the `__setup__` hook of a command's package runs right before the first command of that package if no marker exists. Independent from `enable_package_setup_hook`, which keeps gating install-time setup only. Packages without a hook are untouched. Operator-owned config, no new manifest field.
- **`cdt package inspect`** now shows `Setup: done | pending | n/a (no __setup__ hook)`.

### Why

Setup hooks can be disabled during installation for various reasons using enable_package_setup_hook. However, commands may fail when __setup__ is responsible for installing third-party packages or other dependencies. The new enable_lazy_setup parameter addresses this by deferring __setup__ execution to a later lifecycle stage.

### Safety

- `IsSetupDone` / `MarkSetupDone` refuse an empty package directory (marker can never land in the cwd).
- Setup hook output goes to the command's stdout (unchanged behaviour); docs advise keeping hooks quiet and idempotent, and gitignoring `.setup` in workspace packages.

### Tests

- Unit: marker read/write/guards, `ExecSetupHookFromPackage` writing the marker, frontend lazy path (runs once, no-hook package, disabled by config; skipped on Windows — needs `sh`).
- Shell integration: `test/integration/test-lazy-setup.sh` + 3 fixture packages — gate off by default, first/second run, marker removal, failing hook blocks the command, manual `package setup`, no-hook package, `inspect` states, independence from `enable_package_setup_hook`.
- Docs: `manifest.md` (`__setup__` section), `config.md`, release notes `1.16.0` (adjust version as needed).