### PR TITLE
Check new available versions accurately

### DIFF
--- a/internal/updater/self-updater.go
+++ b/internal/updater/self-updater.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"path"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/criteo/command-launcher/internal/console"
@@ -102,10 +104,45 @@ func (u *SelfUpdater) checkSelfUpdate() <-chan bool {
 			return
 		}
 
-		ch <- u.latestVersion.Version != u.CurrentVersion &&
+		ch <- isNewerVersion(u.latestVersion.Version, u.CurrentVersion) &&
 			u.User.InPartition(u.latestVersion.StartPartition, u.latestVersion.EndPartition)
 	}()
 	return ch
+}
+
+func isNewerVersion(remote, current string) bool {
+	remoteParts, remoteOk := splitVersionInts(remote)
+	currentParts, currentOk := splitVersionInts(current)
+	if !remoteOk || !currentOk {
+		return remote != current
+	}
+
+	for i := 0; i < len(remoteParts) || i < len(currentParts); i++ {
+		var r, c int
+		if i < len(remoteParts) {
+			r = remoteParts[i]
+		}
+		if i < len(currentParts) {
+			c = currentParts[i]
+		}
+		if r != c {
+			return r > c
+		}
+	}
+	return false
+}
+
+func splitVersionInts(v string) ([]int, bool) {
+	parts := strings.Split(v, ".")
+	nums := make([]int, len(parts))
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, false
+		}
+		nums[i] = n
+	}
+	return nums, true
 }
 
 func (u *SelfUpdater) doSelfUpdate(url string) error {

--- a/internal/updater/self-updater_test.go
+++ b/internal/updater/self-updater_test.go
@@ -1,0 +1,24 @@
+package updater
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNewerVersion(t *testing.T) {
+	assert.True(t, isNewerVersion("1.16.0", "1.15.2"))
+	assert.True(t, isNewerVersion("1.10.0", "1.9.0"))
+	assert.False(t, isNewerVersion("1.15.2", "1.16.0"))
+	assert.False(t, isNewerVersion("1.16.0", "1.16.0"))
+	assert.True(t, isNewerVersion("1.16", "1.15.9"))
+	assert.False(t, isNewerVersion("1.16.0", "1.16"))
+	assert.True(t, isNewerVersion("2.0.0", "1.99.99"))
+}
+
+func TestIsNewerVersionFallbackOnNonNumericSuffix(t *testing.T) {
+	assert.True(t, isNewerVersion("1.16.0-beta", "1.15.2"))
+	assert.False(t, isNewerVersion("1.16.0", "1.16.0"))
+	assert.True(t, isNewerVersion("1.16.0", "1.16.0-beta"))
+	assert.False(t, isNewerVersion("1.16.0-beta", "1.16.0-beta"))
+}


### PR DESCRIPTION
Now, version are checked using simple comparison.
If you install newer version, for example from GH, then try to use it locally
and locally latest available version is not as new as for GH, you can see, for example.

Version: 1.16.2

Available 1.15.2, do you want to update,
which is strange and confusing.

Here is a tiny zero-dependency fix that allows to check versions accurately.